### PR TITLE
Correctly desugar mod and slices

### DIFF
--- a/crates/jrsonnet-parser/src/lib.rs
+++ b/crates/jrsonnet-parser/src/lib.rs
@@ -263,7 +263,7 @@ parser! {
 						unaryop(<"~">) _ b:@ { loc_expr_todo!(Expr::UnaryOp(UnaryOpType::BitNot, b)) }
 				--
 				a:(@) _ "[" _ s:slice_desc(s) _ "]" {loc_expr_todo!(Expr::Apply(
-					el!(Expr::Intrinsic("slice".into())),
+					el!(Expr::Index(el!(Expr::Var("std".into())), el!(Expr::Str("slice".into())))),
 					ArgsDesc(vec![
 						Arg(None, a),
 						Arg(None, s.start.unwrap_or_else(||el!(Expr::Literal(LiteralType::Null)))),

--- a/crates/jrsonnet-parser/src/lib.rs
+++ b/crates/jrsonnet-parser/src/lib.rs
@@ -254,7 +254,7 @@ parser! {
 				a:(@) _ binop(<"*">) _ b:@ {loc_expr_todo!(Expr::BinaryOp(a, BinaryOpType::Mul, b))}
 				a:(@) _ binop(<"/">) _ b:@ {loc_expr_todo!(Expr::BinaryOp(a, BinaryOpType::Div, b))}
 				a:(@) _ binop(<"%">) _ b:@ {loc_expr_todo!(Expr::Apply(
-					el!(Expr::Intrinsic("mod".into())), ArgsDesc(vec![Arg(None, a), Arg(None, b)]),
+					el!(Expr::Index(el!(Expr::Var("std".into())), el!(Expr::Str("mod".into())))), ArgsDesc(vec![Arg(None, a), Arg(None, b)]),
 					false
 				))}
 				--


### PR DESCRIPTION
Using both modulo (`a % b`) and slice syntax (`arr[1:2:2]`) failed in all cases because the parser tries to desugar them as intrinsics rather than stdlib functions. These intrinsics do not exist and failed with `intrinsic not found` errors. This PR expands modulo and slice syntax into `std.mod()` and `std.slice()` respectively.

```bash
$ cat tst.jsonnet
{
  a: 5 % 2,
  b: "foo-%s" % 99,
  c: "abcde"[0:3:2],
}
$ jsonnet tst.jsonnet
{
   "a": 1,
   "b": "foo-99",
   "c": "ac"
}
# Before
$ jrsonnet tst.jsonnet
intrinsic not found: mod
    /Users/akursell/dev/jrsonnet/tst.jsonnet:2:6-12: function <std.mod> call

# After
$ jrsonnet tst.jsonnet
{
   "a": 1,
   "b": "foo-99",
   "c": "ac"
}
```