### PR TITLE
Add job to publish to crates.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,36 @@ jobs:
         with:
           command: test
           args: --all
-  release:
+
+  cargo-release:
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Install cargo release command
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: cargo-release
+      - name: Run cargo login
+        uses: actions-rs/cargo@v1
+        with:
+          command: login
+          args: ${{ secrets.CARGO_TOKEN }}
+      - name: Publish crates
+        uses: actions-rs/cargo@v1
+        with:
+          command: release
+          args: --no-dev-version --skip-push --skip-tag --no-confirm
+
+  github-release:
     if: startsWith(github.ref, 'refs/tags/')
     needs: [test]
     strategy:


### PR DESCRIPTION
I'm creating the [`kct`](https://github.com/kseat/kct) CLI, which is very dependent on this project; consequently, I've been watching your changes. Although unable to contribute due to my shallow Rust knowledge. On the other hand, I can help you with releasing your crates to crates.io. That also helps me because I'm keen to try out the 0.3.5 version, which unfortunately wasn't published yet.

For that, I used the [`cargo-release`](https://github.com/sunng87/cargo-release) while disabling all the git functionality so you can have complete control over your release process. I've tested this on [`kct`](https://github.com/kseat/kct/runs/2472200698?check_suite_focus=true#step:7:26) to be sure that everything would work, and it did, despite the build failure. The only problem is if the process fails halfway;  it's unable to pick up from where it left and publish only the remaining.

Just remember that you'll need to configure a secret under `CARGO_TOKEN` for it to work.