### PR TITLE
Use clap prerelease instead of git ref

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,43 +54,15 @@ jobs:
     strategy:
       matrix:
         target:
-          # Tier 1
-          - aarch64-unknown-linux-gnu
-          - i686-pc-windows-gnu
-          - i686-pc-windows-msvc
-          - i686-unknown-linux-gnu
           - x86_64-apple-darwin
-          - x86_64-pc-windows-gnu
           - x86_64-pc-windows-msvc
           - x86_64-unknown-linux-gnu
-
-          # Other
           - x86_64-unknown-linux-musl
         include:
-          - target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
-            bin: jrsonnet
-            name: jrsonnet-linux-gnu-aarch64
-          - target: i686-pc-windows-gnu
-            os: windows-latest
-            bin: jrsonnet.exe
-            name: jrsonnet-windows-gnu-i686.exe
-          - target: i686-pc-windows-msvc
-            os: windows-latest
-            bin: jrsonnet.exe
-            name: jrsonnet-windows-msvc-i686.exe
-          - target: i686-unknown-linux-gnu
-            os: ubuntu-latest
-            bin: jrsonnet
-            name: jrsonnet-linux-gnu-i686
           - target: x86_64-apple-darwin
             os: macOS-latest
             bin: jrsonnet
             name: jrsonnet-darwin-amd64
-          - target: x86_64-pc-windows-gnu
-            os: windows-latest
-            bin: jrsonnet.exe
-            name: jrsonnet-windows-gnu-amd64.exe
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             bin: jrsonnet.exe
@@ -99,7 +71,6 @@ jobs:
             os: ubuntu-latest
             bin: jrsonnet
             name: jrsonnet-linux-gnu-amd64
-
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
             bin: jrsonnet
@@ -116,52 +87,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Linux x86 cross compiler
-        if: ${{ matrix.target == 'i686-unknown-linux-gnu' }}
-        run: sudo apt install gcc-multilib
-
-      - name: Windows x86 cross compiler
-        if: ${{ matrix.target == 'i686-pc-windows-gnu' }}
-        uses: egor-tensin/setup-mingw@v2
-        with:
-          platform: x86
-
-      - name: ARM cross compiler
-        if: ${{ matrix.target == 'aarch64-unknown-linux-gnu' }}
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: cross
-
-      - name: ARM gcc
-        if: ${{ matrix.target == 'aarch64-unknown-linux-gnu' }}
-        run: sudo apt install gcc-aarch64-linux-gnu
-
-      - name: Run ARM build
-        if: ${{ matrix.target == 'aarch64-unknown-linux-gnu' }}
-        shell: bash
-        run: cross build --bin=jrsonnet --release --target ${{ matrix.target }}
-
-      - name: Run ARM strip
-        if: ${{ matrix.target == 'aarch64-unknown-linux-gnu' }}
-        shell: bash
-        run: aarch64-linux-gnu-strip target/${{ matrix.target }}/release/${{ matrix.bin }}
-
       - name: Run build
-        if: ${{ matrix.target != 'aarch64-unknown-linux-gnu' }}
         uses: actions-rs/cargo@v1
         with:
           command: build
           args: --bin=jrsonnet --release --target ${{ matrix.target }}
 
-      - name: Run strip
-        if: ${{ matrix.target != 'aarch64-unknown-linux-gnu' }}
-        shell: bash
-        run: strip target/${{ matrix.target }}/release/${{ matrix.bin }}
-
       - name: Package
         shell: bash
         run: |
+          strip target/${{ matrix.target }}/release/${{ matrix.bin }}
           cd target/${{ matrix.target }}/release
 
           cp ${{ matrix.bin }} ../../../${{ matrix.name }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,8 @@ checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
 [[package]]
 name = "clap"
 version = "3.0.0-beta.2"
-source = "git+https://github.com/clap-rs/clap?rev=92f744cc49d12d32261010d355dc215a6d2487b9#92f744cc49d12d32261010d355dc215a6d2487b9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd1061998a501ee7d4b6d449020df3266ca3124b941ec56cf2005c3779ca142"
 dependencies = [
  "atty",
  "bitflags",
@@ -76,13 +77,15 @@ dependencies = [
  "strsim",
  "termcolor",
  "textwrap",
+ "unicode-width",
  "vec_map",
 ]
 
 [[package]]
 name = "clap_derive"
 version = "3.0.0-beta.2"
-source = "git+https://github.com/clap-rs/clap?rev=92f744cc49d12d32261010d355dc215a6d2487b9#92f744cc49d12d32261010d355dc215a6d2487b9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "370f715b81112975b1b69db93e0b56ea4cd4e5002ac43b2da8474106a54096a1"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -94,7 +97,8 @@ dependencies = [
 [[package]]
 name = "clap_generate"
 version = "3.0.0-beta.2"
-source = "git+https://github.com/clap-rs/clap?rev=92f744cc49d12d32261010d355dc215a6d2487b9#92f744cc49d12d32261010d355dc215a6d2487b9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adf420f8b687b628d2915ccfd43a660c437a170432e3fbcb66944e8717a0d68f"
 dependencies = [
  "clap",
 ]
@@ -266,9 +270,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "3.0.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e293568965aea261bdf010db17df7030e3c9a275c415d51d6112f7cf9b7af012"
+checksum = "afb2e1c3ee07430c2cf76151675e583e0f19985fa6efae47d6848a3e2c824f85"
 
 [[package]]
 name = "pathdiff"
@@ -416,9 +420,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.13.4"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd05616119e612a8041ef58f2b578906cc2531a6069047ae092cfb86a325d835"
+checksum = "203008d98caf094106cfaba70acfed15e18ed3ddb7d94e49baec153a2b462789"
 dependencies = [
  "unicode-width",
 ]

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ This implementation shows performance better than all existing implementations. 
 
 In the end, it's always fun to implement something in Rust.
 
+## How to install?
+
+We build x64 binaries for Apple, Windows MSVC, and Linux GNU during the release process. If your system is one of those, you can check out the [latest release](https://github.com/CertainLach/jrsonnet/releases/latest) to get your pre-built binary. Otherwise, you'll need to have a rust toolchain and install the package through cargo with `cargo install jrsonnet`.
+
 ## Compliance with the [specification](https://jsonnet.org/ref/spec.html)
 
 - Passes all the original `examples` tests

--- a/cmds/jrsonnet/Cargo.toml
+++ b/cmds/jrsonnet/Cargo.toml
@@ -5,7 +5,6 @@ version = "0.3.6"
 authors = ["Yaroslav Bolyukin <iam@lach.pw>"]
 license = "MIT"
 edition = "2018"
-publish = false
 
 [features]
 default = []

--- a/cmds/jrsonnet/Cargo.toml
+++ b/cmds/jrsonnet/Cargo.toml
@@ -19,11 +19,5 @@ jrsonnet-cli = { path = "../../crates/jrsonnet-cli", version = "0.3.6" }
 # TODO: Fix mimalloc compile errors, and use them
 mimallocator = { version = "0.1.3", optional = true }
 thiserror = "1.0"
-
-[dependencies.clap]
-git = "https://github.com/clap-rs/clap"
-rev = "92f744cc49d12d32261010d355dc215a6d2487b9"
-
-[dependencies.clap_generate]
-git = "https://github.com/clap-rs/clap"
-rev = "92f744cc49d12d32261010d355dc215a6d2487b9"
+clap = "3.0.0-beta.2"
+clap_generate = "3.0.0-beta.2"

--- a/crates/jrsonnet-cli/Cargo.toml
+++ b/crates/jrsonnet-cli/Cargo.toml
@@ -10,7 +10,4 @@ publish = false
 [dependencies]
 jrsonnet-evaluator = { path = "../../crates/jrsonnet-evaluator", version = "0.3.6", features = ["explaining-traces"] }
 jrsonnet-parser = { path = "../../crates/jrsonnet-parser", version = "0.3.6" }
-
-[dependencies.clap]
-git = "https://github.com/clap-rs/clap"
-rev = "92f744cc49d12d32261010d355dc215a6d2487b9"
+clap = "3.0.0-beta.2"

--- a/crates/jrsonnet-cli/Cargo.toml
+++ b/crates/jrsonnet-cli/Cargo.toml
@@ -5,7 +5,6 @@ version = "0.3.6"
 authors = ["Yaroslav Bolyukin <iam@lach.pw>"]
 license = "MIT"
 edition = "2018"
-publish = false
 
 [dependencies]
 jrsonnet-evaluator = { path = "../../crates/jrsonnet-evaluator", version = "0.3.6", features = ["explaining-traces"] }

--- a/crates/jrsonnet-interner/.gitignore
+++ b/crates/jrsonnet-interner/.gitignore
@@ -1,2 +1,0 @@
-/target
-Cargo.lock

--- a/crates/jrsonnet-stdlib/Cargo.toml
+++ b/crates/jrsonnet-stdlib/Cargo.toml
@@ -5,7 +5,3 @@ version = "0.3.6"
 authors = ["Yaroslav Bolyukin <iam@lach.pw>"]
 license = "MIT"
 edition = "2018"
-
-[features]
-
-[dependencies]


### PR DESCRIPTION
When trying to build non-x64 binaries, my first attempt was to leverage the Rust Ecosystem. However, that was impossible because of a git dependency, as noted [here](https://github.com/CertainLach/jrsonnet/issues/35#issuecomment-844436711) by @CertainLach. I managed to build the binaries using cross compilers, but the workflows turned out quite ugly. Instead of committing to this workflow, I chose to change from the git ref to the prerelease of clap-rs.

Since using either ref or prerelease gives us the same API stability, I thought you wouldn't consider this to be a problem. Now we can publish the package to crates.io and leverage the Rust Ecosystem for all the non-x64 architectures.

Related-to: #35 