### PR TITLE
Re-export `IStr` in jrsonnet-evaluator crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,7 +223,6 @@ name = "jsonnet"
 version = "0.3.8"
 dependencies = [
  "jrsonnet-evaluator",
- "jrsonnet-interner",
  "jrsonnet-parser",
 ]
 

--- a/bindings/jsonnet/Cargo.toml
+++ b/bindings/jsonnet/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 publish = false
 
 [dependencies]
-jrsonnet-interner = { path = "../../crates/jrsonnet-interner", version = "0.3.8" }
 jrsonnet-evaluator = { path = "../../crates/jrsonnet-evaluator", version = "0.3.8" }
 jrsonnet-parser = { path = "../../crates/jrsonnet-parser", version = "0.3.8" }
 

--- a/bindings/jsonnet/src/import.rs
+++ b/bindings/jsonnet/src/import.rs
@@ -2,9 +2,8 @@
 
 use jrsonnet_evaluator::{
 	error::{Error::*, Result},
-	throw, EvaluationState, ImportResolver,
+	throw, EvaluationState, IStr, ImportResolver,
 };
-use jrsonnet_interner::IStr;
 use std::{
 	any::Any,
 	cell::RefCell,

--- a/bindings/jsonnet/src/lib.rs
+++ b/bindings/jsonnet/src/lib.rs
@@ -9,8 +9,7 @@ pub mod val_modify;
 pub mod vars_tlas;
 
 use import::NativeImportResolver;
-use jrsonnet_evaluator::{EvaluationState, ManifestFormat, Val};
-use jrsonnet_interner::IStr;
+use jrsonnet_evaluator::{EvaluationState, IStr, ManifestFormat, Val};
 use std::{
 	alloc::Layout,
 	ffi::{CStr, CString},

--- a/crates/jrsonnet-evaluator/src/lib.rs
+++ b/crates/jrsonnet-evaluator/src/lib.rs
@@ -26,7 +26,6 @@ use error::{Error::*, LocError, Result, StackTraceElement};
 pub use evaluate::*;
 pub use function::parse_function_call;
 pub use import::*;
-use jrsonnet_interner::IStr;
 use jrsonnet_parser::*;
 use native::NativeCallback;
 pub use obj::*;
@@ -41,6 +40,9 @@ use std::{
 };
 use trace::{offset_to_location, CodeLocation, CompactFormat, TraceFormat};
 pub use val::*;
+
+// Re-exports
+pub use jrsonnet_interner::IStr;
 
 type BindableFn = dyn Fn(Option<ObjValue>, Option<ObjValue>) -> Result<LazyVal>;
 #[derive(Clone)]


### PR DESCRIPTION
So that users of `jrsonnet-evaluator` don't need to explicitly depends on `jrsonnet-interner` just for the `IStr` type.