### PR TITLE
Add location info to all sub-expressions

### DIFF
--- a/crates/jrsonnet-parser/src/expr.rs
+++ b/crates/jrsonnet-parser/src/expr.rs
@@ -403,11 +403,3 @@ macro_rules! loc_expr {
 		)
 	};
 }
-
-/// Creates LocExpr without location info
-#[macro_export]
-macro_rules! loc_expr_todo {
-	($expr:expr) => {
-		LocExpr(Rc::new($expr), None)
-	};
-}


### PR DESCRIPTION
This pull request adds location information to all sub-expressions. So `loc_expr_todo!` is no longer needed.
The added test case `{} { local x = 1, x: x } + {}` previously lacks location information at ObjExtend sub-expression even when `loc_data: true` is given.

I'd like to use jrsonnet-parser crate to detect unused variables in Jsonnet files. Location information is important in this use-case.