### PR TITLE
Fix: Use variable names from jsonnet stdlib for is_x builtins

### DIFF
--- a/crates/jrsonnet-stdlib/src/types.rs
+++ b/crates/jrsonnet-stdlib/src/types.rs
@@ -1,31 +1,31 @@
 use jrsonnet_evaluator::{error::Result, function::builtin, typed::Any, IStr, Val};
 
 #[builtin]
-pub fn builtin_type(x: Any) -> Result<IStr> {
-	Ok(x.0.value_type().name().into())
+pub fn builtin_type(v: Any) -> Result<IStr> {
+	Ok(v.0.value_type().name().into())
 }
 
 #[builtin]
-pub fn builtin_is_string(x: Any) -> Result<bool> {
-	Ok(matches!(x.0, Val::Str(_)))
+pub fn builtin_is_string(v: Any) -> Result<bool> {
+	Ok(matches!(v.0, Val::Str(_)))
 }
 #[builtin]
-pub fn builtin_is_number(x: Any) -> Result<bool> {
-	Ok(matches!(x.0, Val::Num(_)))
+pub fn builtin_is_number(v: Any) -> Result<bool> {
+	Ok(matches!(v.0, Val::Num(_)))
 }
 #[builtin]
-pub fn builtin_is_boolean(x: Any) -> Result<bool> {
-	Ok(matches!(x.0, Val::Bool(_)))
+pub fn builtin_is_boolean(v: Any) -> Result<bool> {
+	Ok(matches!(v.0, Val::Bool(_)))
 }
 #[builtin]
-pub fn builtin_is_object(x: Any) -> Result<bool> {
-	Ok(matches!(x.0, Val::Obj(_)))
+pub fn builtin_is_object(v: Any) -> Result<bool> {
+	Ok(matches!(v.0, Val::Obj(_)))
 }
 #[builtin]
-pub fn builtin_is_array(x: Any) -> Result<bool> {
-	Ok(matches!(x.0, Val::Arr(_)))
+pub fn builtin_is_array(v: Any) -> Result<bool> {
+	Ok(matches!(v.0, Val::Arr(_)))
 }
 #[builtin]
-pub fn builtin_is_function(x: Any) -> Result<bool> {
-	Ok(matches!(x.0, Val::Func(_)))
+pub fn builtin_is_function(v: Any) -> Result<bool> {
+	Ok(matches!(v.0, Val::Func(_)))
 }


### PR DESCRIPTION
This changes the variable name in the identity-related `is_X` builtin functions to match the variable names in the [jsonnet standard library](https://github.com/google/jsonnet/blob/master/stdlib/std.jsonnet#L28,L33).

This mainly serves to integrate better with libraries such as [k8s-libsonnet](https://github.com/jsonnet-libs/k8s-libsonnet/).