### PR TITLE
fix: `.so` build instructions out of date

### DIFF
--- a/bindings/Makefile
+++ b/bindings/Makefile
@@ -1,5 +1,5 @@
 ../target/release/libjsonnet.so:
-	cargo build --release -p jsonnet
+	cargo build --release -p libjsonnet
 
 ./c/libjsonnet_test_file: ./c/libjsonnet_test_file.c ../target/release/libjsonnet.so
 	gcc -L../target/release/ -ljsonnet ./c/libjsonnet_test_file.c -o ./c/libjsonnet_test_file
@@ -11,7 +11,7 @@ test-c: ./c/libjsonnet_test_file ../target/release/libjsonnet.so
 	valgrind --leak-check=full ./c/libjsonnet_test_file test.jsonnet
 
 ../target/wasm32-wasi/release/jsonnet.wasm:
-	cd jsonnet && cargo wasi build --release -p jsonnet && cd ..
+	cd jsonnet && cargo wasi build --release -p libjsonnet && cd ..
 
 test-js: ../target/wasm32-wasi/release/jsonnet.wasm
 	node --experimental-wasi-unstable-preview1 --experimental-wasm-bigint js/index

--- a/bindings/README.md
+++ b/bindings/README.md
@@ -5,3 +5,12 @@ Bindings are implemented in form of standard libjsonnet.so implementation
 Headers are described in `c/libjsonnet.h`, this file is exact copy from `C` implementation of jsonnet, plus additional jrsonnet-specific methods
 
 Bindings should work as drop-in replacement for standard impl
+
+## Building Linux .so library on MacOS
+
+You can use `cross-rs` to do so:
+
+```console
+cargo install cross --git https://github.com/cross-rs/cross
+cross build --release -p libjsonnet --target x86_64-unknown-linux-gnu
+```


### PR DESCRIPTION
I'm working with jrsonnet as a C lib and only managed to build it like this. 
Works great now! Also added instructions to cross-build on MacOS if someone wondered how