### PR TITLE
WIP: Proper tco optimization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "annotate-snippets"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -370,8 +379,11 @@ dependencies = [
  "jrsonnet-gcmodule",
  "jrsonnet-macros",
  "jrsonnet-parser",
+ "lru",
  "md5",
  "num-bigint",
+ "regex",
+ "rustc-hash",
  "serde",
  "serde_json",
  "serde_yaml_with_quirks",
@@ -426,10 +438,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03f1160296536f10c833a82dca22267d5486734230d47bf00bf435885814ba1e"
+dependencies = [
+ "hashbrown 0.13.2",
+]
+
+[[package]]
 name = "md5"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+
+[[package]]
+name = "memchr"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "mimalloc-sys"
@@ -599,6 +626,23 @@ checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "regex"
+version = "1.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "rustc-hash"

--- a/crates/jrsonnet-evaluator/src/evaluate/mod.rs
+++ b/crates/jrsonnet-evaluator/src/evaluate/mod.rs
@@ -1,10 +1,11 @@
-use std::{collections::VecDeque, fmt, marker::PhantomData, rc::Rc};
+use std::{fmt, marker::PhantomData, ops::Deref, rc::Rc};
 
 use jrsonnet_gcmodule::{Cc, Trace};
 use jrsonnet_interner::IStr;
+use jrsonnet_macros::{tco, tcok, tcr};
 use jrsonnet_parser::{
 	ArgsDesc, AssertStmt, BinaryOpType, BindSpec, CompSpec, Expr, FieldMember, FieldName,
-	ForSpecData, IfSpecData, LiteralType, LocExpr, Member, ObjBody, ParamsDesc,
+	ForSpecData, IfSpecData, LiteralType, LocExpr, Member, ObjBody, ParamsDesc, UnaryOpType,
 };
 use jrsonnet_types::ValType;
 
@@ -13,14 +14,14 @@ use crate::{
 	arr::ArrValue,
 	destructure::evaluate_dest,
 	error::{suggest_object_fields, ErrorKind::*},
-	evaluate::operator::{evaluate_add_op, evaluate_binary_op_special, evaluate_unary_op},
+	evaluate::operator::evaluate_unary_op,
 	function::{parse::parse_function_call, CallLocation, FuncDesc, FuncVal},
 	operator::evaluate_binary_op_normal,
 	throw,
-	typed::Typed,
+	typed::{CheckType, Typed},
 	val::{CachedUnbound, IndexableVal, StrValue, Thunk, ThunkValue},
-	Context, ContextBuilder, GcHashMap, ObjValue, ObjValueBuilder, ObjectAssertion, Pending,
-	Result, State, Unbound, Val,
+	Context, GcHashMap, MaybeUnbound, ObjValue, ObjValueBuilder, ObjectAssertion, Pending, Result,
+	State, Unbound, Val,
 };
 pub mod destructure;
 pub mod operator;
@@ -412,7 +413,7 @@ pub fn evaluate_named(ctx: Context, expr: &LocExpr, name: IStr) -> Result<Val> {
 	})
 }
 
-struct Fifo<T> {
+pub(crate) struct Fifo<T> {
 	data: Vec<(T, Tag<T>)>,
 }
 impl<T> Fifo<T> {
@@ -421,43 +422,63 @@ impl<T> Fifo<T> {
 			data: Vec::with_capacity(cap),
 		}
 	}
-	fn single(data: T, tag: Tag<T>) -> Self {
+	fn single(cap: usize, data: T, tag: Tag<T>) -> Self {
 		// eprintln!(">>> {}", tag.0);
-		Self {
-			data: vec![(data, tag)],
-		}
+		let mut out = Self {
+			data: Vec::with_capacity(cap),
+		};
+		out.push(data, tag);
+		out
 	}
-	fn push(&mut self, data: T, tag: Tag<T>) {
+	pub(crate) fn push(&mut self, data: T, tag: Tag<T>) {
 		// eprintln!(">>> {}", tag.0);
 		self.data.push((data, tag));
 	}
 	#[track_caller]
-	fn pop(&mut self, tag: Tag<T>) -> T {
+	pub(crate) fn pop(&mut self, tag: Tag<T>) -> T {
 		// eprintln!("<<< {}", tag.0);
-		let (data, stag) = self.data.pop().unwrap_or_else(|| panic!("underflow querying for {tag:?}"));
-		debug_assert_eq!(
+		let (data, stag) = self
+			.data
+			.pop()
+			.unwrap_or_else(|| panic!("underflow querying for {tag:?}"));
+		// debug_assert doesn't work here, as it always requires PartialEq
+		#[cfg(debug_assertions)]
+		assert_eq!(
 			stag, tag,
 			"mismatched expected {tag:?} and actual {stag:?} tags",
 		);
 		data
 	}
-	fn is_empty(&self) -> bool {
+	pub(crate) fn is_empty(&self) -> bool {
 		self.data.is_empty()
+	}
+	pub(crate) fn len(&self) -> usize {
+		self.data.len()
+	}
+	pub(crate) fn reserve(&mut self, size: usize) {
+		self.data.reserve(size)
 	}
 }
 
-struct Tag<T>(#[cfg(debug_assertions)] &'static str, PhantomData<fn(T)>);
+pub(crate) struct Tag<T> {
+	#[cfg(debug_assertions)]
+	name: &'static str,
+	#[cfg(debug_assertions)]
+	id: u64,
+	_marker: PhantomData<fn(T)>,
+}
 
+#[cfg(debug_assertions)]
 impl<T> PartialEq for Tag<T> {
 	fn eq(&self, other: &Self) -> bool {
-		self.0 == other.0
+		self.name == other.name && self.id == other.id
 	}
 }
 impl<T> fmt::Debug for Tag<T> {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		#[cfg(debug_assertions)]
 		{
-			write!(f, "Tag({})", self.0)
+			write!(f, "Tag({})", self.name)
 		}
 		#[cfg(not(debug_assertions))]
 		{
@@ -465,45 +486,92 @@ impl<T> fmt::Debug for Tag<T> {
 		}
 	}
 }
-macro_rules! val_tag {
-	($ident:ident) => {
-		const $ident: Tag<Val> = Tag(
+impl<T> Clone for Tag<T> {
+	fn clone(&self) -> Self {
+		Self {
 			#[cfg(debug_assertions)]
-			stringify!($ident),
-			PhantomData,
-		);
-	};
+			name: self.name,
+			#[cfg(debug_assertions)]
+			id: self.id.clone(),
+			_marker: self._marker.clone(),
+		}
+	}
 }
-macro_rules! ctx_tag {
-	($ident:ident) => {
-		const $ident: Tag<Context> = Tag(
-			#[cfg(debug_assertions)]
-			stringify!($ident),
-			PhantomData,
-		);
-	};
+impl<T> Copy for Tag<T> {}
+
+#[inline(always)]
+pub(crate) fn val_tag(name: &'static str) -> Tag<Val> {
+	#[cfg(debug_assertions)]
+	{
+		static ID: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0);
+		Tag {
+			name,
+			id: ID.fetch_add(1, core::sync::atomic::Ordering::SeqCst),
+			_marker: PhantomData,
+		}
+	}
+	#[cfg(not(debug_assertions))]
+	{
+		Tag {
+			_marker: PhantomData,
+		}
+	}
+}
+#[inline(always)]
+pub(crate) fn ctx_tag(name: &'static str) -> Tag<Context> {
+	#[cfg(debug_assertions)]
+	{
+		static ID: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0);
+		Tag {
+			name,
+			id: ID.fetch_add(1, core::sync::atomic::Ordering::SeqCst),
+			_marker: PhantomData,
+		}
+	}
+	#[cfg(not(debug_assertions))]
+	{
+		Tag {
+			_marker: PhantomData,
+		}
+	}
 }
 
-const DUMMY_TCA: Tag<TailCallApply> = Tag(
+#[inline(always)]
+pub(crate) fn apply_tag<'a>() -> Tag<TailCallApply> {
 	#[cfg(debug_assertions)]
-	"APPLY",
-	PhantomData,
-);
+	{
+		Tag {
+			name: "APPLY",
+			id: 0,
+			_marker: PhantomData,
+		}
+	}
+	#[cfg(not(debug_assertions))]
+	{
+		Tag {
+			_marker: PhantomData,
+		}
+	}
+}
 
 #[derive(Debug)]
-enum TailCallApply {
+pub(crate) enum TailCallApply {
 	Eval {
 		expr: LocExpr,
 		in_ctx: Tag<Context>,
 		out_val: Tag<Val>,
 	},
-	PushCtx {
-		tag: Tag<Context>,
-		ctx: Context,
+	ParseNormalArgs {
+		params: ParamsDesc,
+		args: ArgsDesc,
+		tailstrict: bool,
+		def_ctx: Tag<Context>,
+		call_ctx: Tag<Context>,
+		out_ctx: Tag<Context>,
 	},
-	ParseNormalArgs(ParamsDesc, ArgsDesc, CallLocation<'static>, bool),
 	IfCond {
 		in_val: Tag<Val>,
+		then_else_ctx: Tag<Context>,
 		then_val: LocExpr,
 		else_val: Option<LocExpr>,
 		out_val: Tag<Val>,
@@ -512,6 +580,15 @@ enum TailCallApply {
 		args: ArgsDesc,
 		location: CallLocation<'static>,
 		tailstrict: bool,
+		lhs_val: Tag<Val>,
+		call_ctx: Tag<Context>,
+		out_val: Tag<Val>,
+	},
+	ApplyBopSpecial {
+		and: bool,
+		a_val: Tag<Val>,
+		b_ctx: Tag<Context>,
+		b_expr: LocExpr,
 		out_val: Tag<Val>,
 	},
 	ApplyBopNormal {
@@ -520,464 +597,482 @@ enum TailCallApply {
 		b_val: Tag<Val>,
 		out_val: Tag<Val>,
 	},
+	ApplyUop {
+		op: UnaryOpType,
+		in_val: Tag<Val>,
+		out_val: Tag<Val>,
+	},
+	EvalObj {
+		in_ctx: Tag<Context>,
+		obj: RcMap<Expr, ObjBody>,
+		out_val: Tag<Val>,
+	},
+	AssertType {
+		in_val: Tag<Val>,
+		out_val: Tag<Val>,
+		ty: ValType,
+	},
+	EvalIndex {
+		lhs_val: Tag<Val>,
+		rhs_val: Tag<Val>,
+		out_val: Tag<Val>,
+	},
+	Unbound {
+		invoke: MaybeUnbound,
+		sup: Option<ObjValue>,
+		this: Option<ObjValue>,
+		out_val: Tag<Val>,
+	},
+}
+#[derive(Debug)]
+pub(crate) struct RcMap<T: ?Sized, U: ?Sized>(Rc<T>, fn(&T) -> &U);
+
+impl<T: ?Sized, U: ?Sized> RcMap<T, U> {
+	fn map(rc: Rc<T>, projection: fn(&T) -> &U) -> Self {
+		RcMap(rc, projection)
+	}
 }
 
-// Until before statement is not stable
-macro_rules! tco_become {
-	($apply:ident, $value:expr) => {
-		$apply.push($value, DUMMY_TCA);
-		continue;
-	};
-}
-macro_rules! tco_queue {
-	($apply:ident, $value:expr) => {
-		$apply.push($value, DUMMY_TCA);
-	};
-}
-macro_rules! tco {
-  //   (@cont $apply:ident, $last:expr) => {
-  //       tco_queue!($apply, $last)
-  //   };
-  //   (@cont $apply:ident, $($pre:expr,)+ $last:expr) => {
-		// tco!(@cont $apply, $($pre),+);
-  //       tco_queue!($apply, $last)
-  //   };
-	(@cont $apply:ident, [] @ $($pre:expr)*) => {{
-		$({
-			let v = $pre;
-			$apply.push(v, DUMMY_TCA);
-		})*
-	}};
-	(@cont $apply:ident, [$first:tt $($tt:tt)*] @ $($pre:expr)*) => {{
-		tco!(@cont $apply, [$($tt)*] @$first $($pre)* );
-	}};
-    ($apply:ident, $($pre:expr),* $(,)?) => {{
-		tco!(@cont $apply, [$({$pre})*] @);
-		continue;
-    }};
+impl<T, U> Deref for RcMap<T, U>
+where
+	T: ?Sized,
+	U: ?Sized,
+{
+	type Target = U;
+
+	fn deref(&self) -> &Self::Target {
+		(self.1)(&*self.0)
+	}
 }
 
-val_tag!(INIT_VAL);
-ctx_tag!(INIT_CTX);
+pub(crate) struct TcVM {
+	pub(crate) vals: Fifo<Val>,
+	pub(crate) ctxs: Fifo<Context>,
+	pub(crate) apply: Fifo<TailCallApply>,
 
-ctx_tag!(FN_BODY_CTX);
-ctx_tag!(FN_DEF_CTX);
+	#[cfg(debug_assertions)]
+	pub(crate) vals_offset: usize,
+	#[cfg(debug_assertions)]
+	pub(crate) ctxs_offset: usize,
+	pub(crate) apply_offset: usize,
+}
+impl TcVM {
+	fn has_apply(&self) -> bool {
+		self.apply.len() > self.apply_offset
+	}
+}
 
-val_tag!(APPLY_LHS_VAL);
-ctx_tag!(APPLY_LHS_CTX);
-
-val_tag!(COND_VAL);
-ctx_tag!(COND_CTX);
-ctx_tag!(COND_THEN_ELSE_CTX);
-
-val_tag!(BOP_LHS_VAL);
-val_tag!(BOP_RHS_VAL);
-ctx_tag!(BOP_LHS_CTX);
-ctx_tag!(BOP_RHS_CTX);
-
-ctx_tag!(BOP_CTX);
-
-#[allow(clippy::too_many_lines)]
-pub fn evaluate<'a>(ctx: Context, expr: &'a LocExpr) -> Result<Val> {
+#[inline(always)]
+fn evaluate_inner(
+	tcvm: &mut TcVM,
+	expr: LocExpr,
+	in_ctx: Tag<Context>,
+	out_val: Tag<Val>,
+) -> Result<()> {
 	use Expr::*;
-	use TailCallApply::*;
+	let ctx = tcvm.ctxs.pop(in_ctx);
 
-	let mut stack = Fifo::<Val>::with_capacity(1);
-	let mut ctxs = Fifo::single(ctx, INIT_CTX);
-	let mut apply = Fifo::<TailCallApply>::single(
-		Eval {
-			expr: expr.clone(),
-			in_ctx: INIT_CTX,
-			out_val: INIT_VAL,
+	if let Some(trivial) = evaluate_trivial(&expr) {
+		tcvm.vals.push(trivial, out_val);
+		return Ok(());
+	}
+	let LocExpr(expr, loc) = expr;
+	tcvm.vals.push(
+		match *expr {
+			Literal(LiteralType::This) => {
+				Val::Obj(ctx.this().ok_or(CantUseSelfOutsideOfObject)?.clone())
+			}
+			Literal(LiteralType::Super) => Val::Obj(
+				ctx.super_obj().ok_or(NoSuperFound)?.with_this(
+					ctx.this()
+						.expect("if super exists - then this should too")
+						.clone(),
+				),
+			),
+			Literal(LiteralType::Dollar) => {
+				Val::Obj(ctx.dollar().ok_or(NoTopLevelObjectFound)?.clone())
+			}
+			Literal(LiteralType::True) => Val::Bool(true),
+			Literal(LiteralType::False) => Val::Bool(false),
+			Literal(LiteralType::Null) => Val::Null,
+			Parened(ref e) => {
+				tcr!(
+					ctx(parened, ctx.clone()),
+					Eval {
+						expr: e.clone(),
+						in_ctx: parened,
+						out_val
+					}
+				);
+				return Ok(());
+			}
+			Str(ref v) => Val::Str(StrValue::Flat(v.clone())),
+			Num(v) => Val::new_checked_num(v)?,
+			BinaryOp(ref v1, op, ref v2) if matches!(op, BinaryOpType::And | BinaryOpType::Or) => {
+				tcr!(
+					ctx(in_ctx, ctx.clone()),
+					Eval {
+						expr: v1.clone(),
+						in_ctx,
+						out_val: val(a_val),
+					},
+					ctx(b_ctx, ctx.clone()),
+					ApplyBopSpecial {
+						a_val,
+						b_ctx,
+						b_expr: v2.clone(),
+						and: op == BinaryOpType::And,
+						out_val,
+					}
+				);
+				return Ok(());
+			}
+			BinaryOp(ref v1, op, ref v2) => {
+				// FIXME: short-circuiting binary op
+				tcr!(
+					ctx(lhsc, ctx.clone()),
+					Eval {
+						expr: v1.clone(),
+						in_ctx: lhsc,
+						out_val: val(a_val),
+					},
+					ctx(rhsc, ctx.clone()),
+					Eval {
+						expr: v2.clone(),
+						in_ctx: rhsc,
+						out_val: val(b_val),
+					},
+					ApplyBopNormal {
+						op,
+						a_val,
+						b_val,
+						out_val,
+					}
+				);
+				return Ok(());
+			}
+			UnaryOp(op, ref v) => {
+				tcr!(
+					ctx(uop, ctx.clone()),
+					Eval {
+						expr: v.clone(),
+						in_ctx: uop,
+						out_val: val(in_val),
+					},
+					ApplyUop {
+						op,
+						in_val,
+						out_val,
+					},
+				);
+				return Ok(());
+			}
+			Var(ref name) => State::push(
+				CallLocation::new(&loc),
+				|| format!("variable <{name}> access"),
+				|| ctx.binding(name.clone())?.evaluate(),
+			)?,
+			Index(LocExpr(ref v, _), ref index)
+				if matches!(&**v, Expr::Literal(LiteralType::Super)) =>
+			{
+				let name = evaluate(ctx.clone(), &index)?;
+				let Val::Str(name) = name else {
+					throw!(ValueIndexMustBeTypeGot(
+						ValType::Obj,
+						ValType::Str,
+						name.value_type(),
+					))
+				};
+				ctx.super_obj()
+					.expect("no super found")
+					.get_for(name.into_flat(), ctx.this().expect("no this found").clone())?
+					.expect("value not found")
+			}
+			Index(ref value, ref index) => {
+				tcr!(
+					ctx(lhsc, ctx.clone()),
+					Eval {
+						expr: value.clone(),
+						in_ctx: lhsc,
+						out_val: val(lhs_val),
+					},
+					ctx(rhsc, ctx.clone()),
+					Eval {
+						expr: index.clone(),
+						in_ctx: rhsc,
+						out_val: val(rhs_val),
+					},
+					EvalIndex {
+						lhs_val,
+						rhs_val,
+						out_val,
+					}
+				);
+				return Ok(());
+			}
+			LocalExpr(ref bindings, ref returned) => {
+				let mut new_bindings: GcHashMap<IStr, Thunk<Val>> =
+					GcHashMap::with_capacity(bindings.iter().map(BindSpec::capacity_hint).sum());
+				let fctx = Context::new_future();
+				for b in bindings {
+					evaluate_dest(&b, fctx.clone(), &mut new_bindings)?;
+				}
+				let ctx = ctx.extend(new_bindings, None, None, None).into_future(fctx);
+				evaluate(ctx, &returned.clone())?
+			}
+			Arr(ref items) => {
+				if items.is_empty() {
+					Val::Arr(ArrValue::empty())
+				} else if items.len() == 1 {
+					#[derive(Trace)]
+					struct ArrayElement {
+						ctx: Context,
+						item: LocExpr,
+					}
+					impl ThunkValue for ArrayElement {
+						type Output = Val;
+						fn get(self: Box<Self>) -> Result<Val> {
+							evaluate(self.ctx, &self.item)
+						}
+					}
+					Val::Arr(ArrValue::lazy(Cc::new(vec![Thunk::new(ArrayElement {
+						ctx,
+						item: items[0].clone(),
+					})])))
+				} else {
+					Val::Arr(ArrValue::expr(ctx, items.iter().cloned()))
+				}
+			}
+			ArrComp(ref expr, ref comp_specs) => {
+				let mut out = Vec::new();
+				evaluate_comp(ctx, &comp_specs, &mut |ctx| {
+					out.push(evaluate(ctx, &expr)?);
+					Ok(())
+				})?;
+				Val::Arr(ArrValue::eager(out))
+			}
+			Obj(ref body) => Val::Obj(evaluate_object(ctx, &body)?),
+			ObjExtend(ref a, _) => {
+				tcr!(
+					ctx(base_ctx, ctx.clone()),
+					Eval {
+						expr: a.clone(),
+						in_ctx: base_ctx,
+						out_val: val(lhs),
+					},
+					ctx(obj_ctx, ctx.clone()),
+					EvalObj {
+						in_ctx: obj_ctx,
+						obj: RcMap::map(expr.clone(), |e| {
+							match e {
+								ObjExtend(_, v) => v,
+								_ => unreachable!(),
+							}
+						}),
+						out_val: val(rhs)
+					},
+					ApplyBopNormal {
+						op: BinaryOpType::Add,
+						a_val: lhs,
+						b_val: rhs,
+						out_val,
+					}
+				);
+				return Ok(());
+			}
+			Apply(ref value, ref args, tailstrict) => tcok!(
+				ctx(in_ctx, ctx.clone()),
+				Eval {
+					expr: value.clone(),
+					in_ctx,
+					out_val: val(lhs_val),
+				},
+				ctx(call_ctx, ctx.clone()),
+				ApplyUnknownFn {
+					args: args.clone(),
+					// TODO: preserve
+					location: CallLocation::native(),
+					tailstrict,
+					call_ctx,
+					lhs_val,
+					out_val,
+				},
+			),
+			Function(ref params, ref body) => {
+				evaluate_method(ctx, "anonymous".into(), params.clone(), body.clone())
+			}
+			AssertExpr(ref assert, ref returned) => {
+				evaluate_assert(ctx.clone(), &assert)?;
+				evaluate(ctx, &returned)?
+			}
+			ErrorStmt(ref e) => State::push(
+				CallLocation::new(&loc),
+				|| "error statement".to_owned(),
+				|| throw!(RuntimeError(evaluate(ctx, &e)?.to_string()?,)),
+			)?,
+			IfElse {
+				ref cond,
+				ref cond_then,
+				ref cond_else,
+			} => {
+				tcr!(
+					ctx(in_ctx, ctx.clone()),
+					Eval {
+						expr: cond.0.clone(),
+						in_ctx,
+						out_val: val(in_val),
+					},
+					ctx(then_else_ctx, ctx.clone()),
+					IfCond {
+						in_val: in_val.clone(),
+						then_else_ctx,
+						then_val: cond_then.clone(),
+						else_val: cond_else.clone(),
+						out_val
+					}
+				);
+				return Ok(());
+			}
+			Slice(ref value, ref desc) => {
+				fn parse_idx<T: Typed>(
+					loc: CallLocation<'_>,
+					ctx: &Context,
+					expr: Option<&LocExpr>,
+					desc: &'static str,
+				) -> Result<Option<T>> {
+					if let Some(value) = expr {
+						Ok(Some(State::push(
+							loc,
+							|| format!("slice {desc}"),
+							|| T::from_untyped(evaluate(ctx.clone(), value)?),
+						)?))
+					} else {
+						Ok(None)
+					}
+				}
+
+				let indexable = evaluate(ctx.clone(), &value)?;
+				let loc = CallLocation::new(&loc);
+
+				let start = parse_idx(loc, &ctx, desc.start.as_ref(), "start")?;
+				let end = parse_idx(loc, &ctx, desc.end.as_ref(), "end")?;
+				let step = parse_idx(loc, &ctx, desc.step.as_ref(), "step")?;
+
+				IndexableVal::into_untyped(indexable.into_indexable()?.slice(start, end, step)?)?
+			}
+			ref i @ (Import(ref path) | ImportStr(ref path) | ImportBin(ref path)) => {
+				let Expr::Str(path) = &*path.0 else {
+						    throw!("computed imports are not supported")
+					    };
+				let tmp = loc.clone().0;
+				let s = ctx.state();
+				let resolved_path = s.resolve_from(tmp.source_path(), path as &str)?;
+				match i {
+					Import(_) => State::push(
+						CallLocation::new(&loc),
+						|| format!("import {:?}", path.clone()),
+						|| s.import_resolved(resolved_path),
+					)?,
+					ImportStr(_) => Val::Str(StrValue::Flat(s.import_resolved_str(resolved_path)?)),
+					ImportBin(_) => {
+						Val::Arr(ArrValue::bytes(s.import_resolved_bin(resolved_path)?))
+					}
+					_ => unreachable!(),
+				}
+			}
 		},
-		DUMMY_TCA,
+		out_val,
 	);
+	Ok(())
+}
 
-	while !apply.is_empty() {
-		let op = apply.pop(DUMMY_TCA);
+pub fn evaluate_reuse_inlined(tcvm: &mut TcVM, expr: &LocExpr) -> Result<()> {
+	use TailCallApply::*;
+	while tcvm.has_apply() {
+		let op = tcvm.apply.pop(apply_tag());
 		match op {
-			TailCallApply::PushCtx { tag, ctx } => ctxs.push(ctx, tag),
 			TailCallApply::Eval {
 				expr,
 				in_ctx,
 				out_val,
-			} => {
-				let ctx = ctxs.pop(in_ctx);
-
-				if let Some(trivial) = evaluate_trivial(&expr) {
-					stack.push(trivial, out_val);
-					continue;
-				}
-				let LocExpr(expr, loc) = expr;
-				stack.push(
-					match &*expr {
-						Literal(LiteralType::This) => {
-							Val::Obj(ctx.this().ok_or(CantUseSelfOutsideOfObject)?.clone())
-						}
-						Literal(LiteralType::Super) => Val::Obj(
-							ctx.super_obj().ok_or(NoSuperFound)?.with_this(
-								ctx.this()
-									.expect("if super exists - then this should too")
-									.clone(),
-							),
-						),
-						Literal(LiteralType::Dollar) => {
-							Val::Obj(ctx.dollar().ok_or(NoTopLevelObjectFound)?.clone())
-						}
-						Literal(LiteralType::True) => Val::Bool(true),
-						Literal(LiteralType::False) => Val::Bool(false),
-						Literal(LiteralType::Null) => Val::Null,
-						Parened(e) => evaluate(ctx, e)?,
-						Str(v) => Val::Str(StrValue::Flat(v.clone())),
-						Num(v) => Val::new_checked_num(*v)?,
-						BinaryOp(v1, o, v2) => {
-							// FIXME: short-circuiting binary op
-							ctxs.push(ctx.clone(), BOP_RHS_CTX);
-							ctxs.push(ctx.clone(), BOP_LHS_CTX);
-							tco!(
-								apply,
-								Eval {
-									expr: v1.clone(),
-									in_ctx: BOP_LHS_CTX,
-									out_val: BOP_LHS_VAL
-								},
-								Eval {
-									expr: v2.clone(),
-									in_ctx: BOP_RHS_CTX,
-									out_val: BOP_RHS_VAL,
-								},
-								ApplyBopNormal {
-									op: *o,
-									a_val: BOP_LHS_VAL,
-									b_val: BOP_RHS_VAL,
-									out_val
-								}
-							);
-						}
-						UnaryOp(o, v) => evaluate_unary_op(*o, &evaluate(ctx, v)?)?,
-						Var(name) => State::push(
-							CallLocation::new(&loc),
-							|| format!("variable <{name}> access"),
-							|| ctx.binding(name.clone())?.evaluate(),
-						)?,
-						Index(LocExpr(v, _), index)
-							if matches!(&**v, Expr::Literal(LiteralType::Super)) =>
-						{
-							let name = evaluate(ctx.clone(), index)?;
-							let Val::Str(name) = name else {
-						    throw!(ValueIndexMustBeTypeGot(
-						    	ValType::Obj,
-						    	ValType::Str,
-						    	name.value_type(),
-						    ))
-					    };
-							ctx.super_obj()
-								.expect("no super found")
-								.get_for(
-									name.into_flat(),
-									ctx.this().expect("no this found").clone(),
-								)?
-								.expect("value not found")
-						}
-						Index(value, index) => {
-							match (evaluate(ctx.clone(), value)?, evaluate(ctx, index)?) {
-								(Val::Obj(v), Val::Str(key)) => State::push(
-									CallLocation::new(&loc),
-									|| format!("field <{key}> access"),
-									|| match v.get(key.clone().into_flat()) {
-										Ok(Some(v)) => Ok(v),
-										Ok(None) => {
-											let suggestions =
-												suggest_object_fields(&v, key.clone().into_flat());
-
-											throw!(NoSuchField(
-												key.clone().into_flat(),
-												suggestions
-											))
-										}
-										Err(e) => Err(e),
-									},
-								)?,
-								(Val::Obj(_), n) => throw!(ValueIndexMustBeTypeGot(
-									ValType::Obj,
-									ValType::Str,
-									n.value_type(),
-								)),
-
-								(Val::Arr(v), Val::Num(n)) => {
-									if n.fract() > f64::EPSILON {
-										throw!(FractionalIndex)
-									}
-									v.get(n as usize)?
-										.ok_or_else(|| ArrayBoundsError(n as usize, v.len()))?
-								}
-								(Val::Arr(_), Val::Str(n)) => {
-									throw!(AttemptedIndexAnArrayWithString(n.into_flat()))
-								}
-								(Val::Arr(_), n) => throw!(ValueIndexMustBeTypeGot(
-									ValType::Arr,
-									ValType::Num,
-									n.value_type(),
-								)),
-
-								(Val::Str(s), Val::Num(n)) => Val::Str({
-									let v: IStr = s
-										.clone()
-										.into_flat()
-										.chars()
-										.skip(n as usize)
-										.take(1)
-										.collect::<String>()
-										.into();
-									if v.is_empty() {
-										let size = s.into_flat().chars().count();
-										throw!(StringBoundsError(n as usize, size))
-									}
-									StrValue::Flat(v)
-								}),
-								(Val::Str(_), n) => throw!(ValueIndexMustBeTypeGot(
-									ValType::Str,
-									ValType::Num,
-									n.value_type(),
-								)),
-
-								(v, _) => throw!(CantIndexInto(v.value_type())),
-							}
-						}
-						LocalExpr(bindings, returned) => {
-							let mut new_bindings: GcHashMap<IStr, Thunk<Val>> =
-								GcHashMap::with_capacity(
-									bindings.iter().map(BindSpec::capacity_hint).sum(),
-								);
-							let fctx = Context::new_future();
-							for b in bindings {
-								evaluate_dest(b, fctx.clone(), &mut new_bindings)?;
-							}
-							let ctx = ctx.extend(new_bindings, None, None, None).into_future(fctx);
-							evaluate(ctx, &returned.clone())?
-						}
-						Arr(items) => {
-							if items.is_empty() {
-								Val::Arr(ArrValue::empty())
-							} else if items.len() == 1 {
-								#[derive(Trace)]
-								struct ArrayElement {
-									ctx: Context,
-									item: LocExpr,
-								}
-								impl ThunkValue for ArrayElement {
-									type Output = Val;
-									fn get(self: Box<Self>) -> Result<Val> {
-										evaluate(self.ctx, &self.item)
-									}
-								}
-								Val::Arr(ArrValue::lazy(Cc::new(vec![Thunk::new(ArrayElement {
-									ctx,
-									item: items[0].clone(),
-								})])))
-							} else {
-								Val::Arr(ArrValue::expr(ctx, items.iter().cloned()))
-							}
-						}
-						ArrComp(expr, comp_specs) => {
-							let mut out = Vec::new();
-							evaluate_comp(ctx, comp_specs, &mut |ctx| {
-								out.push(evaluate(ctx, expr)?);
-								Ok(())
-							})?;
-							Val::Arr(ArrValue::eager(out))
-						}
-						Obj(body) => Val::Obj(evaluate_object(ctx, body)?),
-						ObjExtend(a, b) => evaluate_add_op(
-							&evaluate(ctx.clone(), a)?,
-							&Val::Obj(evaluate_object(ctx, b)?),
-						)?,
-						Apply(value, args, tailstrict) => {
-							tco_queue!(
-								apply,
-								ApplyUnknownFn {
-									args: args.clone(),
-									location: CallLocation::native(),
-									tailstrict: *tailstrict,
-									out_val
-								}
-							);
-							ctxs.push(ctx.clone(), APPLY_LHS_CTX);
-							ctxs.push(ctx, APPLY_LHS_CTX);
-							tco_become!(
-								apply,
-								Eval {
-									expr: value.clone(),
-									in_ctx: APPLY_LHS_CTX,
-									out_val: APPLY_LHS_VAL
-								}
-							);
-						}
-						Function(params, body) => {
-							evaluate_method(ctx, "anonymous".into(), params.clone(), body.clone())
-						}
-						AssertExpr(assert, returned) => {
-							evaluate_assert(ctx.clone(), assert)?;
-							evaluate(ctx, returned)?
-						}
-						ErrorStmt(e) => State::push(
-							CallLocation::new(&loc),
-							|| "error statement".to_owned(),
-							|| throw!(RuntimeError(evaluate(ctx, e)?.to_string()?,)),
-						)?,
-						IfElse {
-							cond,
-							cond_then,
-							cond_else,
-						} => {
-							tco_queue!(
-								apply,
-								IfCond {
-									in_val: COND_VAL,
-									then_val: cond_then.clone(),
-									else_val: cond_else.clone(),
-									out_val
-								}
-							);
-							ctxs.push(ctx.clone(), COND_THEN_ELSE_CTX);
-							ctxs.push(ctx, COND_CTX);
-							tco_become!(
-								apply,
-								Eval {
-									expr: cond.0.clone(),
-									in_ctx: COND_CTX,
-									out_val: COND_VAL
-								}
-							);
-						}
-						Slice(value, desc) => {
-							fn parse_idx<T: Typed>(
-								loc: CallLocation<'_>,
-								ctx: &Context,
-								expr: Option<&LocExpr>,
-								desc: &'static str,
-							) -> Result<Option<T>> {
-								if let Some(value) = expr {
-									Ok(Some(State::push(
-										loc,
-										|| format!("slice {desc}"),
-										|| T::from_untyped(evaluate(ctx.clone(), value)?),
-									)?))
-								} else {
-									Ok(None)
-								}
-							}
-
-							let indexable = evaluate(ctx.clone(), value)?;
-							let loc = CallLocation::new(&loc);
-
-							let start = parse_idx(loc, &ctx, desc.start.as_ref(), "start")?;
-							let end = parse_idx(loc, &ctx, desc.end.as_ref(), "end")?;
-							let step = parse_idx(loc, &ctx, desc.step.as_ref(), "step")?;
-
-							IndexableVal::into_untyped(
-								indexable.into_indexable()?.slice(start, end, step)?,
-							)?
-						}
-						i @ (Import(path) | ImportStr(path) | ImportBin(path)) => {
-							let Expr::Str(path) = &*path.0 else {
-						    throw!("computed imports are not supported")
-					    };
-							let tmp = loc.clone().0;
-							let s = ctx.state();
-							let resolved_path = s.resolve_from(tmp.source_path(), path as &str)?;
-							match i {
-								Import(_) => State::push(
-									CallLocation::new(&loc),
-									|| format!("import {:?}", path.clone()),
-									|| s.import_resolved(resolved_path),
-								)?,
-								ImportStr(_) => {
-									Val::Str(StrValue::Flat(s.import_resolved_str(resolved_path)?))
-								}
-								ImportBin(_) => {
-									Val::Arr(ArrValue::bytes(s.import_resolved_bin(resolved_path)?))
-								}
-								_ => unreachable!(),
-							}
-						}
-					},
-					out_val,
-				);
-			}
+			} => evaluate_inner(&mut tcvm, expr, in_ctx, out_val)?,
 			TailCallApply::ApplyUnknownFn {
 				args,
 				location,
 				tailstrict,
+				lhs_val,
+				call_ctx,
 				out_val,
 			} => {
-				let mut value = stack.pop(APPLY_LHS_VAL);
+				let value = tcvm.vals.pop(lhs_val);
 				let Val::Func(f) = value else {
 					throw!(OnlyFunctionsCanBeCalledGot(value.value_type()));
 				};
 				match f {
-					FuncVal::Id => todo!(),
 					FuncVal::Normal(desc) => {
-						tco_queue!(
-							apply,
+						tco!(
+							ctx(def_ctx, desc.ctx.clone()),
+							ParseNormalArgs {
+								params: desc.params.clone(),
+								args: args,
+								tailstrict,
+								def_ctx,
+								call_ctx,
+								out_ctx: ctx(body_ctx),
+							},
 							Eval {
 								expr: desc.body.clone(),
-								in_ctx: FN_BODY_CTX,
+								in_ctx: body_ctx.clone(),
 								out_val
 							}
 						);
-						ctxs.push(desc.ctx.clone(), FN_DEF_CTX);
-						tco_become!(
-							apply,
-							ParseNormalArgs(desc.params.clone(), args, location, tailstrict)
-						);
 					}
-					FuncVal::StaticBuiltin(_) => todo!(),
-					FuncVal::Builtin(_) => todo!(),
+					FuncVal::Builtin(_) | FuncVal::StaticBuiltin(_) | FuncVal::Id => {
+						// TODO: Proper TCO optimization for builtins
+						let call_ctx = tcvm.ctxs.pop(call_ctx);
+						let out = f.evaluate(call_ctx, location, &args, tailstrict)?;
+						tcvm.vals.push(out, out_val)
+					}
 				}
-				// let body = || f.evaluate(ctx, loc, args, tailstrict);
-				// if tailstrict {
-				// 	body()?
-				// } else {
-				// 	State::push(loc, || format!("function <{}> call", f.name()), body)?
-				// }
 			}
-			ParseNormalArgs(params, args, call, tailstrict) => {
-				let definition_context = ctxs.pop(FN_DEF_CTX);
-				let lhs_ctx = ctxs.pop(APPLY_LHS_CTX);
+			ParseNormalArgs {
+				params,
+				args,
+				tailstrict,
+				def_ctx,
+				call_ctx,
+				out_ctx,
+			} => {
+				let definition_context = tcvm.ctxs.pop(def_ctx);
+				let lhs_ctx = tcvm.ctxs.pop(call_ctx);
 				let ctx =
 					parse_function_call(lhs_ctx, definition_context, &params, &args, tailstrict)?;
-				ctxs.push(ctx, FN_BODY_CTX);
+				tcvm.ctxs.push(ctx, out_ctx);
 			}
 			IfCond {
 				in_val,
+				then_else_ctx,
 				then_val,
 				else_val,
 				out_val,
 			} => {
-				let cond = stack.pop(in_val);
+				let cond = tcvm.vals.pop(in_val);
 				let cond = bool::from_untyped(cond)?;
 				if cond {
-					tco_become!(
-						apply,
-						Eval {
-							expr: then_val,
-							in_ctx: COND_THEN_ELSE_CTX,
-							out_val
-						}
-					);
+					tco!(Eval {
+						expr: then_val,
+						in_ctx: then_else_ctx,
+						out_val
+					});
 				} else if let Some(else_val) = else_val {
-					tco_become!(
-						apply,
-						Eval {
-							expr: else_val,
-							in_ctx: COND_THEN_ELSE_CTX,
-							out_val
-						}
-					);
+					tco!(Eval {
+						expr: else_val,
+						in_ctx: then_else_ctx,
+						out_val
+					});
 				} else {
-					ctxs.pop(COND_THEN_ELSE_CTX);
-					stack.push(Val::Null, out_val)
+					tcvm.ctxs.pop(then_else_ctx);
+					tcvm.vals.push(Val::Null, out_val)
 				}
 			}
 			ApplyBopNormal {
@@ -986,15 +1081,184 @@ pub fn evaluate<'a>(ctx: Context, expr: &'a LocExpr) -> Result<Val> {
 				b_val,
 				out_val,
 			} => {
-				let b = stack.pop(b_val);
-				let a = stack.pop(a_val);
+				let b = tcvm.vals.pop(b_val);
+				let a = tcvm.vals.pop(a_val);
 				let v = evaluate_binary_op_normal(&a, op, &b)?;
-				stack.push(v, out_val);
+				tcvm.vals.push(v, out_val);
+			}
+			ApplyBopSpecial {
+				and,
+				a_val,
+				b_ctx,
+				b_expr,
+				out_val,
+			} => {
+				let a = tcvm.vals.pop(a_val);
+				let a = bool::from_untyped(a)?;
+				let b_ctx = tcvm.ctxs.pop(b_ctx);
+				match (and, a) {
+					(true, false) => tcvm.vals.push(Val::Bool(false), out_val),
+					(false, true) => tcvm.vals.push(Val::Bool(true), out_val),
+					(true, _) => tco!(
+						ctx(in_ctx, b_ctx),
+						Eval {
+							expr: b_expr,
+							in_ctx,
+							out_val: val(res),
+						},
+						AssertType {
+							in_val: res,
+							out_val,
+							ty: ValType::Bool,
+						}
+					),
+					(false, _) => tco!(
+						ctx(in_ctx, b_ctx),
+						Eval {
+							expr: b_expr,
+							in_ctx,
+							out_val: val(res),
+						},
+						AssertType {
+							in_val: res,
+							out_val,
+							ty: ValType::Bool,
+						},
+					),
+				}
+			}
+			ApplyUop {
+				op,
+				in_val,
+				out_val,
+			} => {
+				let v = tcvm.vals.pop(in_val);
+				let o = evaluate_unary_op(op, &v)?;
+				tcvm.vals.push(o, out_val);
+			}
+			EvalObj {
+				in_ctx,
+				obj,
+				out_val,
+			} => {
+				let in_ctx = tcvm.ctxs.pop(in_ctx);
+				let v = evaluate_object(in_ctx, &obj)?;
+				tcvm.vals.push(Val::Obj(v), out_val);
+			}
+			AssertType {
+				in_val,
+				out_val,
+				ty,
+			} => {
+				let val = tcvm.vals.pop(in_val);
+				ty.check(&val)?;
+				tcvm.vals.push(val, out_val)
+			}
+			EvalIndex {
+				lhs_val,
+				rhs_val,
+				out_val,
+			} => {
+				let rhs = tcvm.vals.pop(rhs_val);
+				let lhs = tcvm.vals.pop(lhs_val);
+				let v = match (lhs, rhs) {
+					(Val::Obj(v), Val::Str(key)) => match v.get(key.clone().into_flat()) {
+						Ok(Some(v)) => v,
+						Ok(None) => {
+							let suggestions = suggest_object_fields(&v, key.clone().into_flat());
+
+							throw!(NoSuchField(key.clone().into_flat(), suggestions))
+						}
+						Err(e) => throw!(e),
+					},
+					(Val::Obj(_), n) => throw!(ValueIndexMustBeTypeGot(
+						ValType::Obj,
+						ValType::Str,
+						n.value_type(),
+					)),
+
+					(Val::Arr(v), Val::Num(n)) => {
+						if n.fract() > f64::EPSILON {
+							throw!(FractionalIndex)
+						}
+						v.get(n as usize)?
+							.ok_or_else(|| ArrayBoundsError(n as usize, v.len()))?
+					}
+					(Val::Arr(_), Val::Str(n)) => {
+						throw!(AttemptedIndexAnArrayWithString(n.into_flat()))
+					}
+					(Val::Arr(_), n) => throw!(ValueIndexMustBeTypeGot(
+						ValType::Arr,
+						ValType::Num,
+						n.value_type(),
+					)),
+
+					(Val::Str(s), Val::Num(n)) => Val::Str({
+						let v: IStr = s
+							.clone()
+							.into_flat()
+							.chars()
+							.skip(n as usize)
+							.take(1)
+							.collect::<String>()
+							.into();
+						if v.is_empty() {
+							let size = s.into_flat().chars().count();
+							throw!(StringBoundsError(n as usize, size))
+						}
+						StrValue::Flat(v)
+					}),
+
+					(Val::Str(_), n) => throw!(ValueIndexMustBeTypeGot(
+						ValType::Str,
+						ValType::Num,
+						n.value_type(),
+					)),
+
+					(v, _) => throw!(CantIndexInto(v.value_type())),
+				};
+				tcvm.vals.push(v, out_val)
+			}
+			Unbound {
+				invoke,
+				sup,
+				this,
+				out_val,
+			} => {
+				let o = invoke.evaluate(sup, this)?;
+				tcvm.vals.push(o, out_val)
 			}
 		}
 	}
-	assert!(ctxs.is_empty());
-	assert!(apply.is_empty());
-	assert!(stack.data.len() == 1);
-	Ok(stack.pop(INIT_VAL))
+	Ok(())
+}
+
+#[allow(clippy::too_many_lines)]
+pub fn evaluate(ctx: Context, expr: &LocExpr) -> Result<Val> {
+	let init_ctx = ctx_tag("init");
+	let init_val = val_tag("init");
+
+	let mut tcvm = TcVM {
+		vals: Fifo::<Val>::with_capacity(1),
+		ctxs: Fifo::single(1, ctx, init_ctx.clone()),
+		apply: Fifo::single(
+			1,
+			Eval {
+				expr: expr.clone(),
+				in_ctx: init_ctx.clone(),
+				out_val: init_val.clone(),
+			},
+			apply_tag(),
+		),
+		apply_offset: 0,
+		ctxs_offset: 0,
+		vals_offset: 0,
+	};
+
+	evaluate_reuse_inlined(&mut tcvm, expr);
+
+	debug_assert!(tcvm.ctxs.is_empty(), "ctx remains: {:?}", tcvm.ctxs.data);
+	debug_assert!(tcvm.apply.is_empty());
+	debug_assert!(tcvm.vals.data.len() == 1);
+	Ok(tcvm.vals.pop(init_val))
 }

--- a/crates/jrsonnet-evaluator/src/function/mod.rs
+++ b/crates/jrsonnet-evaluator/src/function/mod.rs
@@ -35,6 +35,15 @@ impl CallLocation<'static> {
 		Self(None)
 	}
 }
+impl Debug for CallLocation<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(_v) = self.0 {
+			write!(f, "Code")
+		} else {
+			write!(f, "Native")
+		}
+    }
+}
 
 /// Represents Jsonnet function defined in code.
 #[derive(Debug, PartialEq, Trace)]

--- a/crates/jrsonnet-evaluator/src/trace/mod.rs
+++ b/crates/jrsonnet-evaluator/src/trace/mod.rs
@@ -1,6 +1,6 @@
 use std::{
 	any::Any,
-	path::{Path, PathBuf},
+	path::{Path, PathBuf, Component},
 };
 
 use jrsonnet_gcmodule::Trace;
@@ -34,6 +34,10 @@ impl PathResolver {
 			Self::Absolute => from.to_string_lossy().into_owned(),
 			Self::Relative(base) => {
 				if from.is_relative() {
+					return from.to_string_lossy().into_owned();
+				}
+				// In case of different disks/different root directory - do not try to diff
+				if base.components().filter(|c| !matches!(c, Component::RootDir)).next() != from.components().filter(|c| !matches!(c, Component::RootDir)).next() {
 					return from.to_string_lossy().into_owned();
 				}
 				pathdiff::diff_paths(from, base)

--- a/crates/jrsonnet-evaluator/src/typed/conversions.rs
+++ b/crates/jrsonnet-evaluator/src/typed/conversions.rs
@@ -223,6 +223,22 @@ impl Typed for String {
 	}
 }
 
+impl Typed for StrValue {
+	const TYPE: &'static ComplexValType = &ComplexValType::Simple(ValType::Str);
+
+	fn into_untyped(value: Self) -> Result<Val> {
+		Ok(Val::Str(value))
+	}
+
+	fn from_untyped(value: Val) -> Result<Self> {
+		<Self as Typed>::TYPE.check(&value)?;
+		match value {
+			Val::Str(s) => Ok(s),
+			_ => unreachable!(),
+		}
+	}
+}
+
 impl Typed for char {
 	const TYPE: &'static ComplexValType = &ComplexValType::Char;
 

--- a/crates/jrsonnet-macros/Cargo.toml
+++ b/crates/jrsonnet-macros/Cargo.toml
@@ -13,4 +13,4 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "1.0", features = ["full"] }
+syn = { version = "1.0", features = ["full", "visit", "derive", "visit-mut"] }

--- a/crates/jrsonnet-parser/src/expr.rs
+++ b/crates/jrsonnet-parser/src/expr.rs
@@ -179,7 +179,8 @@ impl Deref for ParamsDesc {
 
 #[cfg_attr(feature = "structdump", derive(Codegen))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, PartialEq, Trace)]
+// FIXME: remove Clone
+#[derive(Debug, PartialEq, Trace, Clone)]
 pub struct ArgsDesc {
 	pub unnamed: Vec<LocExpr>,
 	pub named: Vec<(IStr, LocExpr)>,

--- a/crates/jrsonnet-stdlib/Cargo.toml
+++ b/crates/jrsonnet-stdlib/Cargo.toml
@@ -42,6 +42,9 @@ serde_json = "1.0"
 serde_yaml_with_quirks = "0.8.24"
 
 num-bigint = { version = "0.4.3", optional = true }
+regex = "1.8.4"
+lru = "0.10.0"
+rustc-hash = "1.1.0"
 
 [build-dependencies]
 jrsonnet-parser.workspace = true

--- a/crates/jrsonnet-stdlib/src/lib.rs
+++ b/crates/jrsonnet-stdlib/src/lib.rs
@@ -44,6 +44,8 @@ mod sets;
 pub use sets::*;
 mod compat;
 pub use compat::*;
+mod regex;
+pub use crate::regex::*;
 
 pub fn stdlib_uncached(settings: Rc<RefCell<Settings>>) -> ObjValue {
 	let mut builder = ObjValueBuilder::new();
@@ -154,6 +156,8 @@ pub fn stdlib_uncached(settings: Rc<RefCell<Settings>>) -> ObjValue {
 		// Sets
 		("setMember", builtin_set_member::INST),
 		("setInter", builtin_set_inter::INST),
+		// Regex
+		("regexQuoteMeta", builtin_regex_quote_meta::INST),
 		// Compat
 		("__compare", builtin___compare::INST),
 	]
@@ -185,6 +189,37 @@ pub fn stdlib_uncached(settings: Rc<RefCell<Settings>>) -> ObjValue {
 		.member("trace".into())
 		.hide()
 		.value(Val::Func(FuncVal::builtin(builtin_trace { settings })))
+		.expect("no conflict");
+
+	// Regex
+	let regex_cache = RegexCache::default();
+	builder
+		.member("regexFullMatch".into())
+		.hide()
+		.value(Val::Func(FuncVal::builtin(builtin_regex_full_match {
+			cache: regex_cache.clone(),
+		})))
+		.expect("no conflict");
+	builder
+		.member("regexPartialMatch".into())
+		.hide()
+		.value(Val::Func(FuncVal::builtin(builtin_regex_partial_match {
+			cache: regex_cache.clone(),
+		})))
+		.expect("no conflict");
+	builder
+		.member("regexReplace".into())
+		.hide()
+		.value(Val::Func(FuncVal::builtin(builtin_regex_replace {
+			cache: regex_cache.clone(),
+		})))
+		.expect("no conflict");
+	builder
+		.member("regexGlobalReplace".into())
+		.hide()
+		.value(Val::Func(FuncVal::builtin(builtin_regex_global_replace {
+			cache: regex_cache.clone(),
+		})))
 		.expect("no conflict");
 
 	builder

--- a/crates/jrsonnet-stdlib/src/misc.rs
+++ b/crates/jrsonnet-stdlib/src/misc.rs
@@ -55,10 +55,11 @@ pub fn builtin_native(this: &builtin_native, x: IStr) -> Val {
 pub fn builtin_trace(
 	this: &builtin_trace,
 	loc: CallLocation,
-	str: IStr,
+	str: Val,
 	rest: Thunk<Val>,
 ) -> Result<Val> {
-	this.settings.borrow().trace_printer.print_trace(loc, str);
+	use jrsonnet_evaluator::error::ResultExt;
+	this.settings.borrow().trace_printer.print_trace(loc, str.to_string().description("std.trace message toString")?);
 	rest.evaluate()
 }
 

--- a/crates/jrsonnet-stdlib/src/regex.rs
+++ b/crates/jrsonnet-stdlib/src/regex.rs
@@ -1,0 +1,134 @@
+use std::{cell::RefCell, hash::BuildHasherDefault, num::NonZeroUsize, rc::Rc};
+
+use ::regex::Regex;
+use jrsonnet_evaluator::{
+	error::{ErrorKind::*, Result},
+	val::StrValue,
+	IStr, ObjValueBuilder, Val,
+};
+use jrsonnet_macros::builtin;
+use lru::LruCache;
+use rustc_hash::FxHasher;
+
+pub struct RegexCacheInner {
+	cache: RefCell<LruCache<IStr, Rc<Regex>, BuildHasherDefault<FxHasher>>>,
+}
+impl Default for RegexCacheInner {
+	fn default() -> Self {
+		Self {
+			cache: RefCell::new(LruCache::with_hasher(
+				NonZeroUsize::new(20).unwrap(),
+				BuildHasherDefault::default(),
+			)),
+		}
+	}
+}
+pub type RegexCache = Rc<RegexCacheInner>;
+impl RegexCacheInner {
+	fn parse(&self, pattern: IStr) -> Result<Rc<Regex>> {
+		let mut cache = self.cache.borrow_mut();
+		if let Some(found) = cache.get(&pattern) {
+			return Ok(found.clone());
+		}
+		let regex = Regex::new(&pattern)
+			.map_err(|e| RuntimeError(format!("regex parse failed: {e}").into()))?;
+		let regex = Rc::new(regex);
+		cache.push(pattern, regex.clone());
+		Ok(regex)
+	}
+}
+
+pub fn regex_match_inner(regex: &Regex, str: String) -> Result<Val> {
+	let mut out = ObjValueBuilder::with_capacity(3);
+
+	let mut captures = Vec::with_capacity(regex.captures_len());
+	let mut named_captures = ObjValueBuilder::with_capacity(regex.capture_names().len());
+
+	let Some(captured) = regex.captures(&str) else {
+		return Ok(Val::Null)
+	};
+
+	for ele in captured.iter().skip(1) {
+		if let Some(ele) = ele {
+			captures.push(Val::Str(StrValue::Flat(ele.as_str().into())))
+		} else {
+			captures.push(Val::Str(StrValue::Flat(IStr::empty())))
+		}
+	}
+	for (i, name) in regex
+		.capture_names()
+		.skip(1)
+		.enumerate()
+		.flat_map(|(i, v)| Some((i, v?)))
+	{
+		let capture = captures[i].clone();
+		named_captures.member(name.into()).value(capture)?;
+	}
+
+	out.member("string".into())
+		.value_unchecked(Val::Str(captured.get(0).unwrap().as_str().into()));
+	out.member("captures".into())
+		.value_unchecked(Val::Arr(captures.into()));
+	out.member("namedCaptures".into())
+		.value_unchecked(Val::Obj(named_captures.build()));
+
+	Ok(Val::Obj(out.build()))
+}
+
+#[builtin(fields(
+    cache: RegexCache,
+))]
+pub fn builtin_regex_partial_match(
+	this: &builtin_regex_partial_match,
+	pattern: IStr,
+	str: String,
+) -> Result<Val> {
+	let regex = this.cache.parse(pattern)?;
+	regex_match_inner(&regex, str)
+}
+
+#[builtin(fields(
+    cache: RegexCache,
+))]
+pub fn builtin_regex_full_match(
+	this: &builtin_regex_full_match,
+	pattern: StrValue,
+	str: String,
+) -> Result<Val> {
+	let pattern = format!("^{pattern}$").into();
+	let regex = this.cache.parse(pattern)?;
+	regex_match_inner(&regex, str)
+}
+
+#[builtin]
+pub fn builtin_regex_quote_meta(pattern: String) -> String {
+	regex::escape(&pattern)
+}
+
+#[builtin(fields(
+    cache: RegexCache,
+))]
+pub fn builtin_regex_replace(
+	this: &builtin_regex_replace,
+	str: String,
+	pattern: IStr,
+	to: String,
+) -> Result<String> {
+	let regex = this.cache.parse(pattern)?;
+	let replaced = regex.replace(&str, to);
+	Ok(replaced.to_string())
+}
+
+#[builtin(fields(
+    cache: RegexCache,
+))]
+pub fn builtin_regex_global_replace(
+	this: &builtin_regex_global_replace,
+	str: String,
+	pattern: IStr,
+	to: String,
+) -> Result<String> {
+	let regex = this.cache.parse(pattern)?;
+	let replaced = regex.replace_all(&str, to);
+	Ok(replaced.to_string())
+}

--- a/flake.nix
+++ b/flake.nix
@@ -73,7 +73,7 @@
             quick = true;
             jrsonnetVariants = [
               { drv = jrsonnet; name = "current"; }
-              { drv = jrsonnet-nightly; name = "current-nightly"; }
+              # { drv = jrsonnet-nightly; name = "current-nightly"; }
               { drv = jrsonnet-release; name = "before-str-extend"; }
             ];
           };

--- a/nix/jrsonnet-release.nix
+++ b/nix/jrsonnet-release.nix
@@ -8,10 +8,10 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "CertainLach";
     repo = pname;
-    rev = "ccafbf79faf649e0990e277c061be9a2b62ad84c";
-    hash = "sha256-LTDIJY9wfv4h5e3/5bONHHBS0qMLKdY6bk6ajKEjG7A=";
+    rev = "777cdf5396004dd5e9447da82c9f081066729d91";
+    hash = "sha256-xfNKSjOZM77NB3mJkTY9RC+ClX5KLyk/Q774vWK0goc=";
   };
-  cargoHash = "sha256-LBlJWE3LcbOe/uu19TbLhbUhBKy8DzuDCP4XyuAEmUk=";
+  cargoHash = "sha256-EJQbOmAD6O5l9YKgd/nFD4Df3PfETQ/ffm2YxxxxW1U=";
 
   cargoTestFlags = [ "--package=jrsonnet --features=mimalloc,legacy-this-file" ];
   cargoBuildFlags = [ "--package=jrsonnet --features=mimalloc,legacy-this-file" ];


### PR DESCRIPTION
 C++ jsonnet does have proper TCO optimization.
However, I haven't used this approach since it is hard to maintain in some cases, especially when it is used in most of the code.
But now I got an idea: Why not implement a hybrid approach where TCO exists only for the main interpreter loop and not in the rest of the codebase, i.e. builtins?
In this PR I explore this possibility, it may also allow for async builtins/std.parallelMap/huge optimizations in recursive functions/better GC root management strategies.

Stack traces and some other things are broken for now, not ready for use.