### PR TITLE
Add Justfile and pre-commit

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,2 @@
+git config core.hooksPath .github/hooks
 use flake

--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+just pre-commit

--- a/Justfile
+++ b/Justfile
@@ -14,3 +14,6 @@ test:
 
 build:
 	cargo build --release
+
+pre-commit:
+	cargo fmt --check

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,16 @@
+[private]
+default:
+	@ just --list --unsorted
+
+lint:
+	cargo fmt --all
+
+test:
+	cargo test \
+		--all --quiet --message-format short \
+		| egrep -v '^running [0-9]+ test' \
+		| egrep -v '^test result' \
+		| egrep -v '^$'
+
+build:
+	cargo build --release

--- a/crates/jrsonnet-parser/src/source.rs
+++ b/crates/jrsonnet-parser/src/source.rs
@@ -32,9 +32,7 @@ macro_rules! any_ext_impl {
 			self.hash(&mut hasher)
 		}
 		fn dyn_eq(&self, other: &dyn $T) -> bool {
-			let Some(other) = other.as_any().downcast_ref::<Self>() else {
-				return false
-			};
+			let Some(other) = other.as_any().downcast_ref::<Self>() else { return false };
 			let this = <Self as $T>::as_any(self)
 				.downcast_ref::<Self>()
 				.expect("restricted by impl");

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
           extensions = [ "rust-src" "miri" "rust-analyzer" ];
         });
       in
-      rec {
+      {
         packages = rec {
           go-jsonnet = pkgs.callPackage ./nix/go-jsonnet.nix { };
           sjsonnet = pkgs.callPackage ./nix/sjsonnet.nix { };
@@ -79,7 +79,7 @@
           };
         };
         devShell = pkgs.mkShell {
-          nativeBuildInputs = with pkgs;[
+          nativeBuildInputs = with pkgs; [
             just
             rust
             cargo-edit
@@ -87,9 +87,10 @@
             cargo-outdated
             lld
             hyperfine
+            graphviz
+          ] ++ lib.optionals (!stdenv.isDarwin) [
             valgrind
             kcachegrind
-            graphviz
           ];
         };
       }

--- a/flake.nix
+++ b/flake.nix
@@ -80,6 +80,7 @@
         };
         devShell = pkgs.mkShell {
           nativeBuildInputs = with pkgs;[
+            just
             rust
             cargo-edit
             cargo-asm


### PR DESCRIPTION
# Justfile

Justfile is a task runner, a simple alternative to Makefile that many use as an "entrypoint" for common dev tasks.

I have include the ones I found most useful contributing to the project.

# pre-commit

If you want external collaborators I think its best that force conformity to the project standards as part of the revision process.

# devShell on Darwin

Some packages are broken, but it doesnt block me from contributing without those tools