### PR TITLE
feat: missing std features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,7 +375,9 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml_with_quirks",
+ "sha1",
  "sha2",
+ "sha3",
  "structdump",
 ]
 
@@ -385,6 +387,15 @@ version = "0.5.0-pre9"
 dependencies = [
  "jrsonnet-gcmodule",
  "peg",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
+dependencies = [
+ "cpufeatures",
 ]
 
 [[package]]
@@ -676,6 +687,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -684,6 +706,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest",
+ "keccak",
 ]
 
 [[package]]

--- a/crates/jrsonnet-stdlib/Cargo.toml
+++ b/crates/jrsonnet-stdlib/Cargo.toml
@@ -32,8 +32,12 @@ serde = "1.0"
 
 # std.md5
 md5 = "0.7.0"
+# std.sha1
+sha1 = "0.10.5"
 # std.sha256, std.sha512
 sha2 = "0.10.6"
+# std.sha3
+sha3 = "0.10.8"
 # std.base64
 base64 = "0.21.0"
 # std.parseJson

--- a/crates/jrsonnet-stdlib/src/arrays.rs
+++ b/crates/jrsonnet-stdlib/src/arrays.rs
@@ -253,3 +253,26 @@ pub fn builtin_avg(arr: Vec<f64>, onEmpty: Option<Thunk<Val>>) -> Result<Val> {
 	}
 	Ok(Val::Num(arr.iter().sum::<f64>() / (arr.len() as f64)))
 }
+
+#[builtin]
+pub fn builtin_remove_at(
+	arr: ArrValue,
+	index: usize,
+) -> Result<ArrValue> {
+	let newArrLeft = arr.clone().slice(None, Some(index), None);
+	let newArrRight = arr.clone().slice(Some(index + 1), None, None);
+	return Ok(ArrValue::extended(
+		newArrLeft.unwrap_or(ArrValue::empty()),
+		newArrRight.unwrap_or(ArrValue::empty()))
+	);
+}
+
+#[builtin]
+pub fn builtin_remove(arr: ArrValue, elem: Val) -> Result<ArrValue> {
+	for (index, item) in arr.iter().enumerate() {
+		if equals(&item?, &elem)? {
+			return builtin_remove_at(arr.clone(), index) 
+		}
+	}
+	Ok(arr)
+}

--- a/crates/jrsonnet-stdlib/src/hash.rs
+++ b/crates/jrsonnet-stdlib/src/hash.rs
@@ -16,3 +16,15 @@ pub fn builtin_sha512(s: IStr) -> String {
 	use sha2::digest::Digest;
 	format!("{:x}", sha2::Sha512::digest(s.as_bytes()))
 }
+
+#[builtin]
+pub fn builtin_sha1(s: IStr) -> String {
+	use sha1::digest::Digest;
+	format!("{:x}", sha1::Sha1::digest(s.as_bytes()))
+}
+
+#[builtin]
+pub fn builtin_sha3(s: IStr) -> String {
+	use sha3::digest::Digest;
+	format!("{:x}", sha3::Sha3_512::digest(s.as_bytes()))
+}

--- a/crates/jrsonnet-stdlib/src/lib.rs
+++ b/crates/jrsonnet-stdlib/src/lib.rs
@@ -149,6 +149,7 @@ pub fn stdlib_uncached(settings: Rc<RefCell<Settings>>) -> ObjValue {
 		("char", builtin_char::INST),
 		("strReplace", builtin_str_replace::INST),
 		("isEmpty", builtin_is_empty::INST),
+		("equalsIgnoreCase", builtin_equals_ignore_case::INST),
 		("splitLimit", builtin_splitlimit::INST),
 		("asciiUpper", builtin_ascii_upper::INST),
 		("asciiLower", builtin_ascii_lower::INST),

--- a/crates/jrsonnet-stdlib/src/lib.rs
+++ b/crates/jrsonnet-stdlib/src/lib.rs
@@ -104,6 +104,7 @@ pub fn stdlib_uncached(settings: Rc<RefCell<Settings>>) -> ObjValue {
 		("exp", builtin_exp::INST),
 		("mantissa", builtin_mantissa::INST),
 		("exponent", builtin_exponent::INST),
+		("round", builtin_round::INST),
 		// Operator
 		("mod", builtin_mod::INST),
 		("primitiveEquals", builtin_primitive_equals::INST),

--- a/crates/jrsonnet-stdlib/src/lib.rs
+++ b/crates/jrsonnet-stdlib/src/lib.rs
@@ -139,6 +139,7 @@ pub fn stdlib_uncached(settings: Rc<RefCell<Settings>>) -> ObjValue {
 		// Objects
 		("objectFieldsEx", builtin_object_fields_ex::INST),
 		("objectHasEx", builtin_object_has_ex::INST),
+		("objectRemoveKey", builtin_object_remove_key::INST),
 		// Manifest
 		("escapeStringJson", builtin_escape_string_json::INST),
 		("manifestJsonEx", builtin_manifest_json_ex::INST),

--- a/crates/jrsonnet-stdlib/src/lib.rs
+++ b/crates/jrsonnet-stdlib/src/lib.rs
@@ -124,8 +124,10 @@ pub fn stdlib_uncached(settings: Rc<RefCell<Settings>>) -> ObjValue {
 		("maxArray", builtin_max_array::INST),
 		// Hash
 		("md5", builtin_md5::INST),
+		("sha1", builtin_sha1::INST),
 		("sha256", builtin_sha256::INST),
 		("sha512", builtin_sha512::INST),
+		("sha3", builtin_sha3::INST),
 		// Encoding
 		("encodeUTF8", builtin_encode_utf8::INST),
 		("decodeUTF8", builtin_decode_utf8::INST),

--- a/crates/jrsonnet-stdlib/src/lib.rs
+++ b/crates/jrsonnet-stdlib/src/lib.rs
@@ -105,6 +105,10 @@ pub fn stdlib_uncached(settings: Rc<RefCell<Settings>>) -> ObjValue {
 		("mantissa", builtin_mantissa::INST),
 		("exponent", builtin_exponent::INST),
 		("round", builtin_round::INST),
+		("isEven", builtin_is_even::INST),
+		("isOdd", builtin_is_odd::INST),
+		("isInteger", builtin_is_integer::INST),
+		("isDecimal", builtin_is_decimal::INST),
 		// Operator
 		("mod", builtin_mod::INST),
 		("primitiveEquals", builtin_primitive_equals::INST),

--- a/crates/jrsonnet-stdlib/src/lib.rs
+++ b/crates/jrsonnet-stdlib/src/lib.rs
@@ -148,6 +148,7 @@ pub fn stdlib_uncached(settings: Rc<RefCell<Settings>>) -> ObjValue {
 		("substr", builtin_substr::INST),
 		("char", builtin_char::INST),
 		("strReplace", builtin_str_replace::INST),
+		("isEmpty", builtin_is_empty::INST),
 		("splitLimit", builtin_splitlimit::INST),
 		("asciiUpper", builtin_ascii_upper::INST),
 		("asciiLower", builtin_ascii_lower::INST),

--- a/crates/jrsonnet-stdlib/src/lib.rs
+++ b/crates/jrsonnet-stdlib/src/lib.rs
@@ -83,6 +83,8 @@ pub fn stdlib_uncached(settings: Rc<RefCell<Settings>>) -> ObjValue {
 		("contains", builtin_member::INST),
 		("count", builtin_count::INST),
 		("avg", builtin_avg::INST),
+		("removeAt", builtin_remove_at::INST),
+		("remove", builtin_remove::INST),
 		// Math
 		("abs", builtin_abs::INST),
 		("sign", builtin_sign::INST),

--- a/crates/jrsonnet-stdlib/src/lib.rs
+++ b/crates/jrsonnet-stdlib/src/lib.rs
@@ -114,6 +114,7 @@ pub fn stdlib_uncached(settings: Rc<RefCell<Settings>>) -> ObjValue {
 		("primitiveEquals", builtin_primitive_equals::INST),
 		("equals", builtin_equals::INST),
 		("xor", builtin_xor::INST),
+		("xnor", builtin_xnor::INST),
 		("format", builtin_format::INST),
 		// Sort
 		("sort", builtin_sort::INST),

--- a/crates/jrsonnet-stdlib/src/math.rs
+++ b/crates/jrsonnet-stdlib/src/math.rs
@@ -114,3 +114,8 @@ pub fn builtin_mantissa(x: f64) -> f64 {
 pub fn builtin_exponent(x: f64) -> i16 {
 	frexp(x).1
 }
+
+#[builtin]
+pub fn builtin_round(x: f64) -> f64 {
+	x.round()
+}

--- a/crates/jrsonnet-stdlib/src/math.rs
+++ b/crates/jrsonnet-stdlib/src/math.rs
@@ -119,3 +119,23 @@ pub fn builtin_exponent(x: f64) -> i16 {
 pub fn builtin_round(x: f64) -> f64 {
 	x.round()
 }
+
+#[builtin]
+pub fn builtin_is_even(x: f64) -> bool {
+	builtin_round(x) % 2.0 == 0.0
+}
+
+#[builtin]
+pub fn builtin_is_odd(x: f64) -> bool {
+	builtin_round(x) % 2.0 == 1.0
+}
+
+#[builtin]
+pub fn builtin_is_integer(x: f64) -> bool {
+	builtin_round(x) == x
+}
+
+#[builtin]
+pub fn builtin_is_decimal(x: f64) -> bool {
+	builtin_round(x) != x
+}

--- a/crates/jrsonnet-stdlib/src/objects.rs
+++ b/crates/jrsonnet-stdlib/src/objects.rs
@@ -1,8 +1,9 @@
 use jrsonnet_evaluator::{
 	function::builtin,
 	val::{StrValue, Val},
-	IStr, ObjValue,
+	IStr, ObjValue, ObjValueBuilder,
 };
+
 
 #[builtin]
 pub fn builtin_object_fields_ex(
@@ -26,4 +27,17 @@ pub fn builtin_object_fields_ex(
 #[builtin]
 pub fn builtin_object_has_ex(obj: ObjValue, fname: IStr, hidden: bool) -> bool {
 	obj.has_field_ex(fname, hidden)
+}
+
+#[builtin]
+pub fn builtin_object_remove_key(obj: ObjValue, key: IStr) -> ObjValue {
+	let mut new_obj = ObjValueBuilder::with_capacity(obj.len() - 1);
+	for (k, v) in obj.iter() {
+		if k == key {
+			continue
+		}
+		new_obj.member(k).value_unchecked(v.unwrap())
+	}
+
+	new_obj.build()
 }

--- a/crates/jrsonnet-stdlib/src/operator.rs
+++ b/crates/jrsonnet-stdlib/src/operator.rs
@@ -39,6 +39,11 @@ pub fn builtin_xor(x: bool, y: bool) -> bool {
 }
 
 #[builtin]
+pub fn builtin_xnor(x: bool, y: bool) -> bool {
+	x == y
+}
+
+#[builtin]
 pub fn builtin_format(str: IStr, vals: Val) -> Result<String> {
 	std_format(&str, vals)
 }

--- a/crates/jrsonnet-stdlib/src/std.jsonnet
+++ b/crates/jrsonnet-stdlib/src/std.jsonnet
@@ -274,6 +274,12 @@
   objectValuesAll(o)::
     [o[k] for k in std.objectFieldsAll(o)],
 
+  objectKeysValues(o)::
+    [{ key: k, value: o[k] } for k in std.objectFields(o)],
+	
+  objectKeysValuesAll(o)::
+		[{ key: k, value: o[k] } for k in std.objectFieldsAll(o)],
+
   resolvePath(f, r)::
     local arr = std.split(f, '/');
     std.join('/', std.makeArray(std.length(arr) - 1, function(i) arr[i]) + [r]),

--- a/crates/jrsonnet-stdlib/src/strings.rs
+++ b/crates/jrsonnet-stdlib/src/strings.rs
@@ -28,6 +28,11 @@ pub fn builtin_str_replace(str: String, from: IStr, to: IStr) -> String {
 }
 
 #[builtin]
+pub fn builtin_is_empty(str: String) -> bool {
+	str.is_empty()
+}
+
+#[builtin]
 pub fn builtin_splitlimit(str: IStr, c: IStr, maxsplits: Either![usize, M1]) -> ArrValue {
 	use Either2::*;
 	match maxsplits {

--- a/crates/jrsonnet-stdlib/src/strings.rs
+++ b/crates/jrsonnet-stdlib/src/strings.rs
@@ -33,6 +33,11 @@ pub fn builtin_is_empty(str: String) -> bool {
 }
 
 #[builtin]
+pub fn builtin_equals_ignore_case(x: String, y: String) -> bool {
+	x.to_ascii_lowercase() == y.to_ascii_lowercase()
+}
+
+#[builtin]
 pub fn builtin_splitlimit(str: IStr, c: IStr, maxsplits: Either![usize, M1]) -> ArrValue {
 	use Either2::*;
 	match maxsplits {


### PR DESCRIPTION
Hey 👋
I've implemented missing std features which were listed in the #118

You can test new features with the following jsonnet snippet:
```
{
	local test = ["a", "b", "a"],
	local obj = {a: "1", b: "2", c:: "3"},
	round1: std.round(1.0),
	round2: std.round(1.2),
	round3: std.round(1.5),
	isEven1: std.isEven(1),
	isEven2: std.isEven(2),
	isOdd1: std.isOdd(1),
	isOdd2: std.isOdd(2),
	isInteger1: std.isInteger(1.0),
	isInteger2: std.isInteger(1.1),
	isDecimal1: std.isDecimal(1.0),
	isDecimal2: std.isDecimal(1.1),
	xnortt: std.xnor(true, true),
	xnortf: std.xnor(true, false),
	xnorff: std.xnor(false, false),
	isEmpty1: std.isEmpty(""),
	isEmpty2: std.isEmpty(" "),
	isEmpty3: std.isEmpty("abc"),
	equalsIgnoreCase1: std.equalsIgnoreCase("a", "ac"),
	equalsIgnoreCase2: std.equalsIgnoreCase("a", "a"),
	equalsIgnoreCase3: std.equalsIgnoreCase("aB", "ab"),
	equalsIgnoreCase4: std.equalsIgnoreCase("aB", "Ab"),
	sha1: std.sha1("abcd"),
	sha3: std.sha3("abcd"),
	remove1: std.remove(["a", "b", "a"], "a"),
	remove2: std.remove(["a", "b", "a"], "c"),
	remove3: std.remove(test, "b"),
	remove4: test,
	remove5: std.removeAt(["a", "b", "a"], 0),
	remove6: std.removeAt(["a", "b", "a"], 1),
	remove7: std.removeAt(["a", "b", "a"], 4),
	objectRemoveKey1: std.objectRemoveKey(obj, "b"),
	objectRemoveKey2: std.objectRemoveKey(obj, "c"),
	objectRemoveKey3: obj,
	objectKeyValues: std.objectKeysValues(obj),
	objectKeyValuesAll: std.objectKeysValuesAll(obj)
}
```

Feel free to leave comments as that's my first time writing some Rust code. 


