### PR TITLE
refactor: use `State::import(..)` for file-sourced TLAs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,9 +37,9 @@ checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "annotate-snippets"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3b9d411ecbaf79885c6df4d75fff75858d5995ff25385657a28af47e82f9c36"
+checksum = "ccaf7e9dfbb6ab22c82e473cd1a8a7bd313c19a5b7e40970f3d89ef5a5c9e81e"
 dependencies = [
  "unicode-width",
  "yansi-term",
@@ -344,7 +344,7 @@ checksum = "7227b28d24aafee21ff72512336c797fa00bb3ea803186b1b105a68abc97660b"
 dependencies = [
  "anyhow",
  "bumpalo",
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "rustc-hash",
  "serde",
  "unicode-width",
@@ -493,9 +493,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
+checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.2",
@@ -1240,9 +1240,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.107"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
+checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
  "itoa",
  "ryu",
@@ -1251,9 +1251,9 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8725e1dfadb3a50f7e5ce0b1a540466f6ed3fe7a0fca2ac2b8b831d31316bd00"
+checksum = "3081f5ffbb02284dda55132aa26daecedd7372a42417bbbab6f14ab7d6bb9145"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1746,7 +1746,7 @@ name = "xtask"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "itertools",
  "proc-macro2",
  "quote",
@@ -1774,18 +1774,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.18"
+version = "0.7.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7d7c7970ca2215b8c1ccf4d4f354c4733201dfaaba72d44ae5b37472e4901"
+checksum = "686b7e407015242119c33dab17b8f61ba6843534de936d94368856528eae4dcc"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.18"
+version = "0.7.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b27b1bb92570f989aac0ab7e9cbfbacdd65973f7ee920d9f0e71ebac878fd0b"
+checksum = "020f3dfe25dfc38dfea49ce62d5d45ecdd7f0d8a724fa63eb36b6eba4ec76806"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/cmds/jrsonnet/src/main.rs
+++ b/cmds/jrsonnet/src/main.rs
@@ -9,7 +9,7 @@ use jrsonnet_cli::{GcOpts, ManifestOpts, MiscOpts, OutputOpts, StdOpts, TlaOpts,
 use jrsonnet_evaluator::{
 	apply_tla, bail,
 	error::{Error as JrError, ErrorKind},
-	ResultExt, State, Val,
+	ImportResolver, ResultExt, State, Val,
 };
 
 #[cfg(feature = "mimalloc")]
@@ -186,13 +186,7 @@ fn main_real(s: &State, opts: Opts) -> Result<(), Error> {
 		s.import(&input)?
 	};
 
-	let (tla, tla_str_paths, tla_code_paths) = opts.tla.tla_opts()?;
-	for path in tla_str_paths {
-		s.import_str(path)?;
-	}
-	for path in tla_code_paths {
-		s.import(path)?;
-	}
+	let tla = opts.tla.into_args_in(s)?;
 	#[allow(unused_mut)]
 	let mut val = apply_tla(s.clone(), &tla, val)?;
 

--- a/cmds/jrsonnet/src/main.rs
+++ b/cmds/jrsonnet/src/main.rs
@@ -9,7 +9,7 @@ use jrsonnet_cli::{GcOpts, ManifestOpts, MiscOpts, OutputOpts, StdOpts, TlaOpts,
 use jrsonnet_evaluator::{
 	apply_tla, bail,
 	error::{Error as JrError, ErrorKind},
-	ImportResolver, ResultExt, State, Val,
+	ResultExt, State, Val,
 };
 
 #[cfg(feature = "mimalloc")]

--- a/cmds/jrsonnet/src/main.rs
+++ b/cmds/jrsonnet/src/main.rs
@@ -186,7 +186,13 @@ fn main_real(s: &State, opts: Opts) -> Result<(), Error> {
 		s.import(&input)?
 	};
 
-	let tla = opts.tla.tla_opts()?;
+	let (tla, tla_str_paths, tla_code_paths) = opts.tla.tla_opts()?;
+	for path in tla_str_paths {
+		s.import_str(path)?;
+	}
+	for path in tla_code_paths {
+		s.import(path)?;
+	}
 	#[allow(unused_mut)]
 	let mut val = apply_tla(s.clone(), &tla, val)?;
 

--- a/crates/jrsonnet-evaluator/src/evaluate/mod.rs
+++ b/crates/jrsonnet-evaluator/src/evaluate/mod.rs
@@ -667,7 +667,7 @@ pub fn evaluate(ctx: Context, expr: &LocExpr) -> Result<Val> {
 			IndexableVal::into_untyped(indexable.into_indexable()?.slice(start, end, step)?)?
 		}
 		i @ (Import(path) | ImportStr(path) | ImportBin(path)) => {
-			let Expr::Str(path) = &*path.0 else {
+			let Str(path) = &*path.0 else {
 				bail!("computed imports are not supported")
 			};
 			let tmp = loc.clone().0;

--- a/crates/jrsonnet-evaluator/src/lib.rs
+++ b/crates/jrsonnet-evaluator/src/lib.rs
@@ -393,6 +393,10 @@ impl State {
 		let resolved = self.resolve(path)?;
 		self.import_resolved(resolved)
 	}
+	pub fn import_str(&self, path: impl AsRef<Path>) -> Result<IStr> {
+		let resolved = self.resolve(path)?;
+		self.import_resolved_str(resolved)
+	}
 
 	/// Creates context with all passed global variables
 	pub fn create_default_context(&self, source: Source) -> Context {
@@ -558,13 +562,17 @@ impl State {
 
 /// Settings utilities
 impl State {
-	// Only panics in case of [`ImportResolver`] contract violation
+	// # Panics
+	//
+	// If [`ImportResolver`] contract is violated.
 	#[allow(clippy::missing_panics_doc)]
 	pub fn resolve_from(&self, from: &SourcePath, path: &str) -> Result<SourcePath> {
 		self.import_resolver().resolve_from(from, path.as_ref())
 	}
 
-	// Only panics in case of [`ImportResolver`] contract violation
+	// # Panics
+	//
+	// If [`ImportResolver`] contract is violated.
 	#[allow(clippy::missing_panics_doc)]
 	pub fn resolve(&self, path: impl AsRef<Path>) -> Result<SourcePath> {
 		self.import_resolver().resolve(path.as_ref())

--- a/crates/jrsonnet-evaluator/src/lib.rs
+++ b/crates/jrsonnet-evaluator/src/lib.rs
@@ -346,7 +346,7 @@ impl State {
 		let file_name = Source::new(path.clone(), code.clone());
 		if file.parsed.is_none() {
 			file.parsed = Some(
-				jrsonnet_parser::parse(
+				parse(
 					&code,
 					&ParserSettings {
 						source: file_name.clone(),
@@ -522,7 +522,7 @@ impl State {
 	pub fn evaluate_snippet(&self, name: impl Into<IStr>, code: impl Into<IStr>) -> Result<Val> {
 		let code = code.into();
 		let source = Source::new_virtual(name.into(), code.clone());
-		let parsed = jrsonnet_parser::parse(
+		let parsed = parse(
 			&code,
 			&ParserSettings {
 				source: source.clone(),
@@ -543,7 +543,7 @@ impl State {
 	) -> Result<Val> {
 		let code = code.into();
 		let source = Source::new_virtual(name.into(), code.clone());
-		let parsed = jrsonnet_parser::parse(
+		let parsed = parse(
 			&code,
 			&ParserSettings {
 				source: source.clone(),

--- a/crates/jrsonnet-stdlib/src/lib.rs
+++ b/crates/jrsonnet-stdlib/src/lib.rs
@@ -352,8 +352,6 @@ impl jrsonnet_evaluator::ContextInitializer for ContextInitializer {
 	}
 	#[cfg(feature = "legacy-this-file")]
 	fn populate(&self, source: Source, builder: &mut ContextBuilder) {
-		use jrsonnet_evaluator::val::StrValue;
-
 		let mut std = ObjValueBuilder::new();
 		std.with_super(self.stdlib_obj.clone());
 		std.field("thisFile")


### PR DESCRIPTION
# Description

This replaces `TlaOpts::{tla_str_file, tla_code_file}` `Vec` values with `PathBuf` and enables the usage of `State::import_*` methods for them.

This also adds `State::import_str`.
