### PR TITLE
fix: lazy object comprehension

### DIFF
--- a/cmds/jrsonnet/Cargo.toml
+++ b/cmds/jrsonnet/Cargo.toml
@@ -15,6 +15,7 @@ experimental = [
     "exp-object-iteration",
     "exp-bigint",
     "exp-apply",
+    "exp-regex",
 ]
 # Use mimalloc as allocator
 mimalloc = ["mimallocator"]


### PR DESCRIPTION
Array comprehension should be able to depend on its own result, and it is able in go-jsonnet/cpp-jsonnet.

Has minimal impact on the performance in the most cases.

Discovered while implementing day 4 of advent of code 2023.
https://github.com/CertainLach/AOC-2023/blob/2ab792288ecfd558473efe2fb3c1eca19f574814/day4.jsonnet#L23