### PR TITLE
nix: add darwin support and default package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
     rust-overlay,
     ...
   }:
-    flake-utils.lib.eachSystem (with flake-utils.lib.system; [x86_64-linux x86_64-windows]) (
+    flake-utils.lib.eachSystem (with flake-utils.lib.system; [x86_64-linux x86_64-windows x86_64-darwin]) (
       system: let
         pkgs = import nixpkgs {
           inherit system;
@@ -34,6 +34,7 @@
           };
       in {
         packages = rec {
+          default = jrsonnet;
           go-jsonnet = pkgs.callPackage ./nix/go-jsonnet.nix {};
           sjsonnet = pkgs.callPackage ./nix/sjsonnet.nix {};
           jsonnet = pkgs.callPackage ./nix/jsonnet.nix {};


### PR DESCRIPTION
## Reasoning

- Building on `x86_64-darwin` seems to work fine, both for jrsonnet package and devShell.
- `package.default` let's you run `nix build .` to build jrsonnet. Same deal when using this flake 
as an input to other ones.

Appreciate all the work!
