### PR TITLE
native implementation of std.splitLimitR

### DIFF
--- a/crates/jrsonnet-stdlib/src/lib.rs
+++ b/crates/jrsonnet-stdlib/src/lib.rs
@@ -178,6 +178,7 @@ pub fn stdlib_uncached(settings: Rc<RefCell<Settings>>) -> ObjValue {
 		("isEmpty", builtin_is_empty::INST),
 		("equalsIgnoreCase", builtin_equals_ignore_case::INST),
 		("splitLimit", builtin_splitlimit::INST),
+		("splitLimitR", builtin_splitlimitr::INST),
 		("asciiUpper", builtin_ascii_upper::INST),
 		("asciiLower", builtin_ascii_lower::INST),
 		("findSubstr", builtin_find_substr::INST),

--- a/crates/jrsonnet-stdlib/src/std.jsonnet
+++ b/crates/jrsonnet-stdlib/src/std.jsonnet
@@ -20,13 +20,6 @@
   stripChars(str, chars)::
     std.lstripChars(std.rstripChars(str, chars), chars),
 
-  splitLimitR(str, c, maxsplits)::
-    if maxsplits == -1 then
-      std.splitLimit(str, c, -1)
-    else
-      local revStr(str) = std.join('', std.reverse(std.stringChars(str)));
-      std.map(function(e) revStr(e), std.reverse(std.splitLimit(revStr(str), revStr(c), maxsplits))),
-
   split(str, c):: std.splitLimit(str, c, -1),
 
   mapWithIndex(func, arr)::

--- a/crates/jrsonnet-stdlib/src/strings.rs
+++ b/crates/jrsonnet-stdlib/src/strings.rs
@@ -47,6 +47,21 @@ pub fn builtin_splitlimit(str: IStr, c: IStr, maxsplits: Either![usize, M1]) -> 
 }
 
 #[builtin]
+pub fn builtin_splitlimitr(str: IStr, c: IStr, maxsplits: Either![usize, M1]) -> ArrValue {
+	use Either2::*;
+	match maxsplits {
+		A(n) =>
+			// rsplitn does not implement DoubleEndedIterator so collect into
+			// a temporary vec
+			str
+				.rsplitn(n + 1, &c as &str)
+				.map(Val::string)
+				.collect::<Vec<_>>().into_iter().rev().collect(),
+		B(_) => str.split(&c as &str).map(Val::string).collect(),
+	}
+}
+
+#[builtin]
 pub fn builtin_ascii_upper(str: IStr) -> String {
 	str.to_ascii_uppercase()
 }

--- a/crates/jrsonnet-stdlib/src/strings.rs
+++ b/crates/jrsonnet-stdlib/src/strings.rs
@@ -51,12 +51,16 @@ pub fn builtin_splitlimitr(str: IStr, c: IStr, maxsplits: Either![usize, M1]) ->
 	use Either2::*;
 	match maxsplits {
 		A(n) =>
-			// rsplitn does not implement DoubleEndedIterator so collect into
-			// a temporary vec
-			str
-				.rsplitn(n + 1, &c as &str)
+		// rsplitn does not implement DoubleEndedIterator so collect into
+		// a temporary vec
+		{
+			str.rsplitn(n + 1, &c as &str)
 				.map(Val::string)
-				.collect::<Vec<_>>().into_iter().rev().collect(),
+				.collect::<Vec<_>>()
+				.into_iter()
+				.rev()
+				.collect()
+		}
 		B(_) => str.split(&c as &str).map(Val::string).collect(),
 	}
 }

--- a/tests/golden/builtin_strings.jsonnet
+++ b/tests/golden/builtin_strings.jsonnet
@@ -1,0 +1,7 @@
+local str = 'ab::cd::ef';
+{
+	split: std.split(str, '::'),
+	splitlimit: std.splitLimit(str, '::', 1),
+	splitlimitRNoLimit: std.splitLimit(str, '::', -1),
+	splitlimitR: std.splitLimitR(str, '::', 1),
+}

--- a/tests/golden/builtin_strings.jsonnet.golden
+++ b/tests/golden/builtin_strings.jsonnet.golden
@@ -1,0 +1,20 @@
+{
+    "split": [
+        "ab",
+        "cd",
+        "ef"
+    ],
+    "splitlimit": [
+        "ab",
+        "cd::ef"
+    ],
+    "splitlimitR": [
+        "ab::cd",
+        "ef"
+    ],
+    "splitlimitRNoLimit": [
+        "ab",
+        "cd",
+        "ef"
+    ]
+}


### PR DESCRIPTION
There are two branches with native implementations of stdlib functions, but none for `std.splitLimirR` yet.

The function needs either two passes over the string (one reverse scan for the nth separator, another to split it starting at this offset) or a temporary array with string slices. The implementation below uses the second, more readable approach.