### PR TITLE
nix: fix broken flake

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,9 +112,9 @@ macro_expanded_macro_exports_accessed_by_absolute_paths = "allow"
 all = "warn"
 
 [workspace.lints.clippy]
-all = "warn"
-nursery = "warn"
-pedantic = "warn"
+all = { level = "warn", priority = -1 }
+nursery = { level = "warn", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
 
 ptr_arg = "allow"
 # Too verbose

--- a/crates/jrsonnet-evaluator/src/stdlib/format.rs
+++ b/crates/jrsonnet-evaluator/src/stdlib/format.rs
@@ -317,6 +317,8 @@ pub fn render_integer(
 	} else {
 		let mut v = iv.abs();
 		let mut nums = Vec::with_capacity(1);
+
+		#[allow(clippy::while_float)]
 		while v != 0.0 {
 			nums.push((v % radix) as u8);
 			v = (v / radix).floor();

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714536327,
-        "narHash": "sha256-zu4+LcygJwdyFHunTMeDFltBZ9+hoWvR/1A7IEy7ChA=",
+        "lastModified": 1717951870,
+        "narHash": "sha256-hGLeRxSEeFz9WvmQ4s4AuMJ5InLSZvoczDdXkWSFi1A=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "3124551aebd8db15d4560716d4f903bd44c64e4a",
+        "rev": "17d9e9dedd58dde2c562a4296934c6d6a0844534",
         "type": "github"
       },
       "original": {
@@ -40,11 +40,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1714595735,
-        "narHash": "sha256-8MDOiHrg2mOylcC7wpx1U1mk9V5VranG7wKyenhHnic=",
+        "lastModified": 1717954073,
+        "narHash": "sha256-nNNWljrTZJY7ihhEDKumf6OFQBOxu7cu/7GGrozNjNM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9d7a1659bc5c6be24ac46407b91807c6e3e0227d",
+        "rev": "7b9135d3ae24bf15ca0fac57f4114c99e28bec3b",
         "type": "github"
       },
       "original": {
@@ -71,11 +71,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714529851,
-        "narHash": "sha256-YMKJW880f7LHXVRzu93xa6Ek+QLECIu0IRQbXbzZe38=",
+        "lastModified": 1717899611,
+        "narHash": "sha256-9Z95F8lnY/5sOf7Z4IdABKz1ulB0ueNrZU864rQj280=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "9ca720fdcf7865385ae3b93ecdf65f1a64cb475e",
+        "rev": "1f536afad5c18ea4ae6bb592c3fef038e1e33568",
         "type": "github"
       },
       "original": {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2024-05-10"
+channel = "nightly-2024-06-09"
 components = ["rustfmt", "clippy", "rust-analyzer", "rust-src"]


### PR DESCRIPTION
## Summary

It looks like there may have been a typo in [here](https://github.com/CertainLach/jrsonnet/pull/160/files#diff-2b1bde2cf3a858b7bf7424cb8bcbf01f35b94dc80b925d9432cbab3319ca9b4e). Should have been nightly-2024-05-01 and not nightly-2024-05-10. The [rev](https://github.com/oxalica/rust-overlay/commit/9ca720fdcf7865385ae3b93ecdf65f1a64cb475e) for rust-overlay in flake.lock doesn't support this nightly.

Bumping nightly and the toolchain file
