### PR TITLE
Fix bigint serialization in ToStringFormat

### DIFF
--- a/crates/jrsonnet-evaluator/src/manifest.rs
+++ b/crates/jrsonnet-evaluator/src/manifest.rs
@@ -355,6 +355,11 @@ impl ManifestFormat for ToStringFormat {
 			out.push_str(&str);
 			return Ok(());
 		}
+		#[cfg(feature = "exp-bigint")]
+		if let Some(int) = val.as_bigint() {
+			out.push_str(&int.to_str_radix(10));
+			return Ok(());
+		}
 		JSON_TO_STRING.manifest_buf(val, out)
 	}
 	fn file_trailing_newline(&self) -> bool {

--- a/crates/jrsonnet-evaluator/src/val.rs
+++ b/crates/jrsonnet-evaluator/src/val.rs
@@ -582,6 +582,13 @@ impl Val {
 			_ => None,
 		}
 	}
+	#[cfg(feature = "exp-bigint")]
+	pub fn as_bigint(&self) -> Option<num_bigint::BigInt> {
+		match self {
+			Self::BigInt(n) => Some(*n.clone()),
+			_ => None,
+		}
+	}
 	pub fn as_arr(&self) -> Option<ArrValue> {
 		match self {
 			Self::Arr(a) => Some(a.clone()),


### PR DESCRIPTION
This PR removes redundant quotes in bigint serialization