### PR TITLE
More math operations for bigint

### DIFF
--- a/crates/jrsonnet-evaluator/src/evaluate/operator.rs
+++ b/crates/jrsonnet-evaluator/src/evaluate/operator.rs
@@ -11,17 +11,12 @@ use crate::{
 	arr::ArrValue,
 	bail,
 	error::ErrorKind::*,
-	evaluate, runtime_error,
+	evaluate,
 	stdlib::std_format,
 	typed::Typed,
-	val::{equals, primitive_equals, StrValue},
+	val::{equals, StrValue},
 	Context, Result, Val,
 };
-
-#[cfg(feature = "exp-bigint")]
-fn num_to_bigint(num: &NumValue) -> Result<num_bigint::BigInt> {
-	num_bigint::BigInt::from_f64(**num).ok_or_else(|| runtime_error!("bigint from number"))
-}
 
 pub fn evaluate_unary_op(op: UnaryOpType, b: &Val) -> Result<Val> {
 	use UnaryOpType::*;


### PR DESCRIPTION
Today I was surprised to learn that in jrsonnet you cannot divide bigints, you cannot multiply them with regular numbers, and changing the order of the operands can break everything. This PR brings order to the basic operations (except for bitwise operations) and makes the following changes:

1. ~~BigInt can now be compared with regular numbers.~~
2. ~~BigInt can now be added to regular numbers.~~
3. ~~BigInt can now be subtracted from regular numbers.~~
4. BigInt can now be divided, and got the remainder.
5. ~~Strings can now be multiplied by BigInt. Also, the bug with `number * str` (instead of `str * number`) has been fixed.~~

All operations are now in separate functions. The changes were tested using the [tests.zip](https://github.com/user-attachments/files/22982274/tests.zip) scripts.

Ideally, we should also have binary operations for bigint and strict comparison between regular numbers and bigint. But this is not a big problem right now, and I will leave it for other PRs.