### PR TITLE
ci: add GitHub Actions workflow for release binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,80 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            artifact: jrsonnet-linux-amd64
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            artifact: jrsonnet-linux-aarch64
+          - target: i686-unknown-linux-gnu
+            os: ubuntu-latest
+            artifact: jrsonnet-linux-i686
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            artifact: jrsonnet-darwin-amd64
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            artifact: jrsonnet-darwin-aarch64
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            artifact: jrsonnet-windows-amd64.exe
+          - target: i686-pc-windows-msvc
+            os: windows-latest
+            artifact: jrsonnet-windows-i686.exe
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install cross-compilation tools (Linux aarch64)
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+
+      - name: Install cross-compilation tools (Linux i686)
+        if: matrix.target == 'i686-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-multilib
+
+      - name: Build
+        env:
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+        run: cargo build --release --target ${{ matrix.target }}
+      - name: Prepare artifact (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          cp target/${{ matrix.target }}/release/jrsonnet ${{ matrix.artifact }}
+          shasum -a 256 ${{ matrix.artifact }} | cut -d ' ' -f 1 > ${{ matrix.artifact }}.sha256
+
+      - name: Prepare artifact (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          cp target/${{ matrix.target }}/release/jrsonnet.exe ${{ matrix.artifact }}
+          sha256sum ${{ matrix.artifact }} | cut -d ' ' -f 1 > ${{ matrix.artifact }}.sha256
+
+      - name: Upload to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload ${{ github.event.release.tag_name }} ${{ matrix.artifact }} ${{ matrix.artifact }}.sha256


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that builds release binaries when a release is published. Produces the same artifact set as previous manual releases:

- linux: amd64, aarch64, i686
- darwin: amd64, aarch64
- windows: amd64, i686

Each binary is accompanied by a `.sha256` checksum file.

## Motivation

There's no CI for building release binaries currently (#70). This workflow automates what was previously a manual process, making it easier to cut releases.

Tested on my fork: https://github.com/vivainio/jrsonnet/actions/runs/24253870017 — all 7 targets built successfully.

## Test plan

- [x] All 7 build targets succeed (verified on fork)
- [x] Binaries and checksums uploaded to release page