### PR TITLE
fix: std.format accepts boolean for numeric conversion codes

### DIFF
--- a/crates/jrsonnet-evaluator/src/stdlib/format.rs
+++ b/crates/jrsonnet-evaluator/src/stdlib/format.rs
@@ -15,7 +15,7 @@ use num_bigint::BigUint;
 use thiserror::Error;
 
 use crate::{
-	Error, ObjValue, Result, Val, bail,
+	Error, NumValue, ObjValue, Result, Val, bail,
 	error::{ErrorKind::*, format_found, suggest_object_fields},
 	typed::{Codepoint, FromUntyped},
 };
@@ -657,6 +657,17 @@ pub fn render_float_sci(
 	out.push_str(&exponent_str);
 }
 
+/// Coerce a boolean to its numeric equivalent (true -> 1.0, false -> 0.0).
+/// Python's `bool` is a subclass of `int`, so `"%d" % True` returns `"1"`.
+/// The Jsonnet spec says formatting follows Python's rules, so we match that.
+fn coerce_bool_to_num(value: &Val) -> Val {
+	match value {
+		Val::Bool(true) => Val::Num(NumValue::new(1.0).expect("finite")),
+		Val::Bool(false) => Val::Num(NumValue::new(0.0).expect("finite")),
+		other => other.clone(),
+	}
+}
+
 #[allow(clippy::too_many_lines)]
 pub fn format_code(
 	out: &mut String,
@@ -679,7 +690,7 @@ pub fn format_code(
 	match code.convtype {
 		ConvTypeV::String => tmp_out.push_str(&value.clone().to_string()?),
 		ConvTypeV::Decimal => {
-			let value = f64::from_untyped(value.clone())?;
+			let value = f64::from_untyped(coerce_bool_to_num(value))?;
 			render_decimal(
 				&mut tmp_out,
 				value <= -1.0,
@@ -691,7 +702,7 @@ pub fn format_code(
 			);
 		}
 		ConvTypeV::Octal => {
-			let value = f64::from_untyped(value.clone())?;
+			let value = f64::from_untyped(coerce_bool_to_num(value))?;
 			render_octal(
 				&mut tmp_out,
 				value <= -1.0,
@@ -704,7 +715,7 @@ pub fn format_code(
 			);
 		}
 		ConvTypeV::Hexadecimal => {
-			let value = f64::from_untyped(value.clone())?;
+			let value = f64::from_untyped(coerce_bool_to_num(value))?;
 			render_hexadecimal(
 				&mut tmp_out,
 				value,
@@ -717,7 +728,7 @@ pub fn format_code(
 			);
 		}
 		ConvTypeV::Scientific => {
-			let value = f64::from_untyped(value.clone())?;
+			let value = f64::from_untyped(coerce_bool_to_num(value))?;
 			render_float_sci(
 				&mut tmp_out,
 				value,
@@ -731,7 +742,7 @@ pub fn format_code(
 			);
 		}
 		ConvTypeV::Float => {
-			let value = f64::from_untyped(value.clone())?;
+			let value = f64::from_untyped(coerce_bool_to_num(value))?;
 			render_float(
 				&mut tmp_out,
 				value,
@@ -744,7 +755,7 @@ pub fn format_code(
 			);
 		}
 		ConvTypeV::Shorter => {
-			let value = f64::from_untyped(value.clone())?;
+			let value = f64::from_untyped(coerce_bool_to_num(value))?;
 			let fpprec = fpprec.max(1);
 			let exponent = shorter_exponent(value, fpprec);
 			if exponent < -4 || exponent >= i32::from(fpprec) {
@@ -773,7 +784,7 @@ pub fn format_code(
 				);
 			}
 		}
-		ConvTypeV::Char => match value.clone() {
+		ConvTypeV::Char => match coerce_bool_to_num(value) {
 			v @ Val::Num(_) => {
 				let codepoint = Codepoint::from_untyped(v)?;
 				tmp_out.push(codepoint.try_char()?);


### PR DESCRIPTION
## Summary

The [official Jsonnet spec](https://jsonnet.org/ref/stdlib.html#std-format) states:
> The string formatting follows the same rules as Python.

In Python, `bool` is a subclass of `int`, so `"%d" % True` returns `"1"`. However, jrsonnet currently rejects booleans for all numeric conversion codes with `type error: expected number, got boolean`.

This fix coerces `Val::Bool(true)` to `Val::Num(1.0)` and `Val::Bool(false)` to `Val::Num(0.0)` before numeric conversion in `format_code()`, matching Python's behavior.

The `%s` conversion is intentionally left unchanged, as Python's `"%s" % True` returns `"True"` (not `"1"`).

Related upstream PRs: google/jsonnet#1328, google/go-jsonnet#884

### Before / After

| Expression | Python | jrsonnet (before) | jrsonnet (after) |
|---|---|---|---|
| `"%d" % true` | `"1"` | ERROR | `"1"` |
| `"%f" % false` | `"0.000000"` | ERROR | `"0.000000"` |
| `"%x" % true` | `"1"` | ERROR | `"1"` |
| `"%o" % true` | `"1"` | ERROR | `"1"` |
| `"%e" % true` | `"1.000000e+00"` | ERROR | `"1.000000e+00"` |
| `"%g" % true` | `"1"` | ERROR | `"1"` |
| `"%c" % true` | `"\x01"` | ERROR | `"\x01"` |
| `"%s" % true` | `"True"` | `"true"` | `"true"` (unchanged) |

## Test plan
- [x] Existing format tests continue to pass (`cargo test -p jrsonnet-evaluator` -- 7/7 passed)
- [x] Boolean coercion matches Python's `bool` -> `int` behavior for all numeric codes (`%d`, `%o`, `%x`, `%e`, `%f`, `%g`)
- [x] Boolean coercion applied for `%c` (character code) matching Python
- [x] `%s` conversion unaffected -- booleans still render as `"true"`/`"false"`